### PR TITLE
Fail fast when calling main-thread-only function in wrong thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Contributions are very welcome! Especially to the medium-level API.
 
 ### Low-level API code generation
 
-`reaper-low` has several generated files, namely `bindings.rs` and `reaper.rs`.
+`reaper-low` has several generated files, namely `bindings.rs`, `reaper.rs` and `swell.rs`.
 These files are not generated with each build though. In order to decrease build time and improve
 IDE/debugging support, they are included in the Git repository like any other Rust source.
 

--- a/main/high/Cargo.toml
+++ b/main/high/Cargo.toml
@@ -12,11 +12,8 @@ categories = ["api-bindings", "multimedia", "multimedia::audio"]
 publish = false
 
 [features]
-# Activates metering of functions which can be safely executed in the main thread only.
-reaper-measure-main = ["reaper-medium/reaper-measure-main"]
-
-# Activates metering of functions which can be safely executed in the real-time audio thread.
-reaper-measure-audio = ["reaper-medium/reaper-measure-audio"]
+# Activates measuring of function execution times.
+reaper-meter = ["reaper-medium/reaper-meter"]
 
 [dependencies]
 c_str_macro = "1.0.2"

--- a/main/high/Cargo.toml
+++ b/main/high/Cargo.toml
@@ -11,6 +11,13 @@ edition = "2018"
 categories = ["api-bindings", "multimedia", "multimedia::audio"]
 publish = false
 
+[features]
+# Activates metering of functions which can be safely executed in the main thread only.
+reaper-measure-main = ["reaper-medium/reaper-measure-main"]
+
+# Activates metering of functions which can be safely executed in the real-time audio thread.
+reaper-measure-audio = ["reaper-medium/reaper-measure-audio"]
+
 [dependencies]
 c_str_macro = "1.0.2"
 once_cell = "1.3.1"

--- a/main/high/src/fx.rs
+++ b/main/high/src/fx.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use crate::fx_chain::FxChain;
 use crate::fx_parameter::FxParameter;
 use crate::guid::Guid;
-use crate::{ChunkRegion, Reaper, Track};
+use crate::{ChunkRegion, Track};
 use reaper_medium::{FxShowInstruction, Hwnd, ReaperFunctions, TrackFxLocation};
 use rxrust::prelude::PayloadCopy;
 

--- a/main/high/src/fx.rs
+++ b/main/high/src/fx.rs
@@ -7,7 +7,7 @@ use crate::fx_chain::FxChain;
 use crate::fx_parameter::FxParameter;
 use crate::guid::Guid;
 use crate::{ChunkRegion, Reaper, Track};
-use reaper_medium::{FxShowInstruction, Hwnd, TrackFxLocation};
+use reaper_medium::{FxShowInstruction, Hwnd, ReaperFunctions, TrackFxLocation};
 use rxrust::prelude::PayloadCopy;
 
 #[derive(Clone, Eq, Debug)]
@@ -62,7 +62,7 @@ impl Fx {
     pub fn get_name(&self) -> CString {
         self.load_if_necessary_or_complain();
         unsafe {
-            Reaper::get().medium().functions().track_fx_get_fx_name(
+            ReaperFunctions::get().track_fx_get_fx_name(
                 self.track.get_raw(),
                 self.get_query_index(),
                 256,
@@ -114,9 +114,7 @@ impl Fx {
     pub fn get_parameter_count(&self) -> u32 {
         self.load_if_necessary_or_complain();
         unsafe {
-            Reaper::get()
-                .medium()
-                .functions()
+            ReaperFunctions::get()
                 .track_fx_get_num_params(self.track.get_raw(), self.get_query_index())
                 as u32
         }
@@ -124,9 +122,7 @@ impl Fx {
 
     pub fn is_enabled(&self) -> bool {
         unsafe {
-            Reaper::get()
-                .medium()
-                .functions()
+            ReaperFunctions::get()
                 .track_fx_get_enabled(self.track.get_raw(), self.get_query_index())
         }
     }
@@ -241,19 +237,14 @@ impl Fx {
     pub fn get_floating_window(&self) -> Option<Hwnd> {
         self.load_if_necessary_or_complain();
         unsafe {
-            Reaper::get()
-                .medium()
-                .functions()
+            ReaperFunctions::get()
                 .track_fx_get_floating_window(self.track.get_raw(), self.get_query_index())
         }
     }
 
     pub fn window_is_open(&self) -> bool {
         unsafe {
-            Reaper::get()
-                .medium()
-                .functions()
-                .track_fx_get_open(self.track.get_raw(), self.get_query_index())
+            ReaperFunctions::get().track_fx_get_open(self.track.get_raw(), self.get_query_index())
         }
     }
 
@@ -278,7 +269,7 @@ impl Fx {
     pub fn show_in_floating_window(&self) {
         self.load_if_necessary_or_complain();
         unsafe {
-            Reaper::get().medium().functions().track_fx_show(
+            ReaperFunctions::get().track_fx_show(
                 self.track.get_raw(),
                 FxShowInstruction::ShowFloatingWindow(self.get_query_index()),
             );
@@ -302,7 +293,7 @@ impl Fx {
 
     pub fn enable(&self) {
         unsafe {
-            Reaper::get().medium().functions().track_fx_set_enabled(
+            ReaperFunctions::get().track_fx_set_enabled(
                 self.track.get_raw(),
                 self.get_query_index(),
                 true,
@@ -312,7 +303,7 @@ impl Fx {
 
     pub fn disable(&self) {
         unsafe {
-            Reaper::get().medium().functions().track_fx_set_enabled(
+            ReaperFunctions::get().track_fx_set_enabled(
                 self.track.get_raw(),
                 self.get_query_index(),
                 false,
@@ -337,9 +328,7 @@ impl Fx {
         self.load_if_necessary_or_complain();
         // TODO-low Integrate into ReaPlus (current preset index?)
         unsafe {
-            Reaper::get()
-                .medium()
-                .functions()
+            ReaperFunctions::get()
                 .track_fx_get_preset_index(self.track.get_raw(), self.get_query_index())
         }
         .expect("Couldn't get preset count")
@@ -349,7 +338,7 @@ impl Fx {
     pub fn preset_is_dirty(&self) -> bool {
         self.load_if_necessary_or_complain();
         !unsafe {
-            Reaper::get().medium().functions().track_fx_get_preset(
+            ReaperFunctions::get().track_fx_get_preset(
                 self.track.get_raw(),
                 self.get_query_index(),
                 0,
@@ -361,7 +350,7 @@ impl Fx {
     pub fn get_preset_name(&self) -> Option<CString> {
         self.load_if_necessary_or_complain();
         unsafe {
-            Reaper::get().medium().functions().track_fx_get_preset(
+            ReaperFunctions::get().track_fx_get_preset(
                 self.track.get_raw(),
                 self.get_query_index(),
                 2000,
@@ -373,13 +362,8 @@ impl Fx {
 
 pub fn get_fx_guid(track: &Track, index: u32, is_input_fx: bool) -> Option<Guid> {
     let query_index = get_fx_query_index(index, is_input_fx);
-    let internal = unsafe {
-        Reaper::get()
-            .medium()
-            .functions()
-            .track_fx_get_fx_guid(track.get_raw(), query_index)
-    }
-    .ok();
+    let internal =
+        unsafe { ReaperFunctions::get().track_fx_get_fx_guid(track.get_raw(), query_index) }.ok();
     internal.map(Guid::new)
 }
 

--- a/main/high/src/fx_chain.rs
+++ b/main/high/src/fx_chain.rs
@@ -2,7 +2,9 @@ use crate::fx::{get_fx_guid, Fx};
 use crate::guid::Guid;
 use crate::{get_fx_query_index, Chunk, ChunkRegion, Reaper, Track, MAX_TRACK_CHUNK_SIZE};
 
-use reaper_medium::{AddFxBehavior, ChunkCacheHint, TrackFxChainType, TransferBehavior};
+use reaper_medium::{
+    AddFxBehavior, ChunkCacheHint, ReaperFunctions, TrackFxChainType, TransferBehavior,
+};
 use std::ffi::CStr;
 
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -17,38 +19,21 @@ impl FxChain {
     }
 
     pub fn get_fx_count(&self) -> u32 {
-        let reaper = Reaper::get();
+        let functions = ReaperFunctions::get();
         if self.is_input_fx {
-            unsafe {
-                reaper
-                    .medium()
-                    .functions()
-                    .track_fx_get_rec_count(self.track.get_raw()) as u32
-            }
+            unsafe { functions.track_fx_get_rec_count(self.track.get_raw()) as u32 }
         } else {
-            unsafe {
-                reaper
-                    .medium()
-                    .functions()
-                    .track_fx_get_count(self.track.get_raw()) as u32
-            }
+            unsafe { functions.track_fx_get_count(self.track.get_raw()) as u32 }
         }
     }
 
     // Moves within this FX chain
     pub fn move_fx(&self, fx: &Fx, new_index: u32) {
         assert_eq!(fx.get_chain(), *self);
-        let reaper = Reaper::get();
-        if reaper
-            .medium()
-            .functions()
-            .low()
-            .pointers()
-            .TrackFX_CopyToTrack
-            .is_some()
-        {
+        let functions = ReaperFunctions::get();
+        if functions.low().pointers().TrackFX_CopyToTrack.is_some() {
             unsafe {
-                reaper.medium().functions().track_fx_copy_to_track(
+                functions.track_fx_copy_to_track(
                     (self.track.get_raw(), fx.get_query_index()),
                     (
                         self.track.get_raw(),
@@ -101,19 +86,10 @@ impl FxChain {
         if !fx.is_available() {
             return;
         }
-        let reaper = Reaper::get();
-        if reaper
-            .medium()
-            .functions()
-            .low()
-            .pointers()
-            .TrackFX_Delete
-            .is_some()
-        {
+        let functions = ReaperFunctions::get();
+        if functions.low().pointers().TrackFX_Delete.is_some() {
             unsafe {
-                reaper
-                    .medium()
-                    .functions()
+                functions
                     .track_fx_delete(self.track.get_raw(), fx.get_query_index())
                     .expect("couldn't delete track FX")
             };
@@ -233,18 +209,13 @@ DOCKED 0
         if self.is_input_fx {
             return None;
         }
-        unsafe {
-            Reaper::get()
-                .medium()
-                .functions()
-                .track_fx_get_instrument(self.track.get_raw())
-        }
-        .and_then(|fx_index| self.get_fx_by_index(fx_index))
+        unsafe { ReaperFunctions::get().track_fx_get_instrument(self.track.get_raw()) }
+            .and_then(|fx_index| self.get_fx_by_index(fx_index))
     }
 
     pub fn add_fx_by_original_name(&self, original_fx_name: &CStr) -> Option<Fx> {
         let fx_index = unsafe {
-            Reaper::get().medium().functions().track_fx_add_by_name_add(
+            ReaperFunctions::get().track_fx_add_by_name_add(
                 self.track.get_raw(),
                 original_fx_name,
                 if self.is_input_fx {
@@ -274,18 +245,15 @@ DOCKED 0
 
     pub fn get_first_fx_by_name(&self, name: &CStr) -> Option<Fx> {
         let fx_index = unsafe {
-            Reaper::get()
-                .medium()
-                .functions()
-                .track_fx_add_by_name_query(
-                    self.track.get_raw(),
-                    name,
-                    if self.is_input_fx {
-                        TrackFxChainType::InputFxChain
-                    } else {
-                        TrackFxChainType::NormalFxChain
-                    },
-                )
+            ReaperFunctions::get().track_fx_add_by_name_query(
+                self.track.get_raw(),
+                name,
+                if self.is_input_fx {
+                    TrackFxChainType::InputFxChain
+                } else {
+                    TrackFxChainType::NormalFxChain
+                },
+            )
         }?;
         Some(Fx::from_guid_and_index(
             self.track.clone(),

--- a/main/high/src/fx_chain.rs
+++ b/main/high/src/fx_chain.rs
@@ -1,6 +1,6 @@
 use crate::fx::{get_fx_guid, Fx};
 use crate::guid::Guid;
-use crate::{get_fx_query_index, Chunk, ChunkRegion, Reaper, Track, MAX_TRACK_CHUNK_SIZE};
+use crate::{get_fx_query_index, Chunk, ChunkRegion, Track, MAX_TRACK_CHUNK_SIZE};
 
 use reaper_medium::{
     AddFxBehavior, ChunkCacheHint, ReaperFunctions, TrackFxChainType, TransferBehavior,

--- a/main/high/src/fx_parameter.rs
+++ b/main/high/src/fx_parameter.rs
@@ -1,7 +1,9 @@
 use crate::fx::Fx;
 use crate::Reaper;
 
-use reaper_medium::{GetParameterStepSizesResult, MediaTrack, ReaperNormalizedFxParamValue};
+use reaper_medium::{
+    GetParameterStepSizesResult, MediaTrack, ReaperFunctions, ReaperNormalizedFxParamValue,
+};
 use rxrust::prelude::PayloadCopy;
 use std::ffi::CString;
 
@@ -26,23 +28,18 @@ impl FxParameter {
 
     pub fn set_normalized_value(&self, normalized_value: ReaperNormalizedFxParamValue) {
         let _ = unsafe {
-            Reaper::get()
-                .medium()
-                .functions()
-                .track_fx_set_param_normalized(
-                    self.get_track_raw(),
-                    self.fx.get_query_index(),
-                    self.index,
-                    normalized_value,
-                )
+            ReaperFunctions::get().track_fx_set_param_normalized(
+                self.get_track_raw(),
+                self.fx.get_query_index(),
+                self.index,
+                normalized_value,
+            )
         };
     }
 
     pub fn get_reaper_value(&self) -> ReaperNormalizedFxParamValue {
         unsafe {
-            Reaper::get()
-                .medium()
-                .functions()
+            ReaperFunctions::get()
                 .track_fx_get_param_normalized(
                     self.fx.get_track().get_raw(),
                     self.fx.get_query_index(),
@@ -58,7 +55,7 @@ impl FxParameter {
 
     pub fn get_name(&self) -> CString {
         unsafe {
-            Reaper::get().medium().functions().track_fx_get_param_name(
+            ReaperFunctions::get().track_fx_get_param_name(
                 self.get_track_raw(),
                 self.fx.get_query_index(),
                 self.index,
@@ -74,14 +71,11 @@ impl FxParameter {
 
     pub fn get_character(&self) -> FxParameterCharacter {
         let result = unsafe {
-            Reaper::get()
-                .medium()
-                .functions()
-                .track_fx_get_parameter_step_sizes(
-                    self.get_track_raw(),
-                    self.fx.get_query_index(),
-                    self.index,
-                )
+            ReaperFunctions::get().track_fx_get_parameter_step_sizes(
+                self.get_track_raw(),
+                self.fx.get_query_index(),
+                self.index,
+            )
         };
         use GetParameterStepSizesResult::*;
         match result {
@@ -93,15 +87,12 @@ impl FxParameter {
 
     pub fn get_formatted_value(&self) -> CString {
         unsafe {
-            Reaper::get()
-                .medium()
-                .functions()
-                .track_fx_get_formatted_param_value(
-                    self.get_track_raw(),
-                    self.fx.get_query_index(),
-                    self.index,
-                    256,
-                )
+            ReaperFunctions::get().track_fx_get_formatted_param_value(
+                self.get_track_raw(),
+                self.fx.get_query_index(),
+                self.index,
+                256,
+            )
         }
         .expect("Couldn't format FX param value")
     }
@@ -119,16 +110,13 @@ impl FxParameter {
         normalized_value: ReaperNormalizedFxParamValue,
     ) -> CString {
         unsafe {
-            Reaper::get()
-                .medium()
-                .functions()
-                .track_fx_format_param_value_normalized(
-                    self.get_track_raw(),
-                    self.fx.get_query_index(),
-                    self.index,
-                    normalized_value,
-                    256,
-                )
+            ReaperFunctions::get().track_fx_format_param_value_normalized(
+                self.get_track_raw(),
+                self.fx.get_query_index(),
+                self.index,
+                normalized_value,
+                256,
+            )
         }
         .expect("Couldn't format normalized value")
     }
@@ -139,14 +127,11 @@ impl FxParameter {
     // of REAPER's return  values.
     pub fn get_step_size(&self) -> Option<f64> {
         let result = unsafe {
-            Reaper::get()
-                .medium()
-                .functions()
-                .track_fx_get_parameter_step_sizes(
-                    self.get_track_raw(),
-                    self.fx.get_query_index(),
-                    self.index,
-                )
+            ReaperFunctions::get().track_fx_get_parameter_step_sizes(
+                self.get_track_raw(),
+                self.fx.get_query_index(),
+                self.index,
+            )
         }?;
         use GetParameterStepSizesResult::*;
         match result {
@@ -172,7 +157,7 @@ impl FxParameter {
     // Doesn't necessarily return normalized values
     pub fn get_value_range(&self) -> FxParameterValueRange {
         let result = unsafe {
-            Reaper::get().medium().functions().track_fx_get_param_ex(
+            ReaperFunctions::get().track_fx_get_param_ex(
                 self.get_track_raw(),
                 self.fx.get_query_index(),
                 self.index,

--- a/main/high/src/fx_parameter.rs
+++ b/main/high/src/fx_parameter.rs
@@ -1,6 +1,5 @@
 use crate::fx::Fx;
 
-
 use reaper_medium::{
     GetParameterStepSizesResult, MediaTrack, ReaperFunctions, ReaperNormalizedFxParamValue,
 };

--- a/main/high/src/fx_parameter.rs
+++ b/main/high/src/fx_parameter.rs
@@ -1,5 +1,5 @@
 use crate::fx::Fx;
-use crate::Reaper;
+
 
 use reaper_medium::{
     GetParameterStepSizesResult, MediaTrack, ReaperFunctions, ReaperNormalizedFxParamValue,

--- a/main/high/src/guid.rs
+++ b/main/high/src/guid.rs
@@ -1,4 +1,3 @@
-
 use reaper_low::raw::GUID;
 use std::convert;
 

--- a/main/high/src/guid.rs
+++ b/main/high/src/guid.rs
@@ -1,4 +1,4 @@
-use crate::Reaper;
+
 use reaper_low::raw::GUID;
 use std::convert;
 

--- a/main/high/src/guid.rs
+++ b/main/high/src/guid.rs
@@ -2,6 +2,7 @@ use crate::Reaper;
 use reaper_low::raw::GUID;
 use std::convert;
 
+use reaper_medium::ReaperFunctions;
 use std::ffi::{CStr, CString};
 use std::fmt;
 use std::fmt::Formatter;
@@ -18,10 +19,7 @@ impl Guid {
     }
 
     pub fn to_string_with_braces(&self) -> String {
-        let c_string = Reaper::get()
-            .medium()
-            .functions()
-            .guid_to_string(&self.internal);
+        let c_string = ReaperFunctions::get().guid_to_string(&self.internal);
         c_string.into_string().unwrap()
     }
 
@@ -41,10 +39,7 @@ impl fmt::Debug for Guid {
 
 impl From<&Guid> for CString {
     fn from(guid: &Guid) -> Self {
-        Reaper::get()
-            .medium()
-            .functions()
-            .guid_to_string(&guid.internal)
+        ReaperFunctions::get().guid_to_string(&guid.internal)
     }
 }
 
@@ -52,9 +47,7 @@ impl convert::TryFrom<&CStr> for Guid {
     type Error = &'static str;
 
     fn try_from(value: &CStr) -> Result<Guid, Self::Error> {
-        Reaper::get()
-            .medium()
-            .functions()
+        ReaperFunctions::get()
             .string_to_guid(value)
             .map(Guid::new)
             .map_err(|_| "Invalid GUID")

--- a/main/high/src/lib.rs
+++ b/main/high/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(fn_traits, clamp, backtrace)]
+#![feature(fn_traits, clamp, backtrace, test)]
 //! This crate contains the high-level API of [reaper-rs](https://github.com/helgoboss/reaper-rs).
 //!
 //! **This API is not polished yet and will still undergo many changes!**
@@ -79,3 +79,19 @@ pub use action_character::*;
 mod undo_block;
 
 mod normalized_value;
+
+#[cfg(test)]
+mod tests {
+    extern crate test;
+    use test::Bencher;
+
+    #[bench]
+    fn thread_comparison_speed(b: &mut Bencher) {
+        let main_thread_id = std::thread::current().id();
+        b.iter(|| {
+            std::thread::spawn(|| 5);
+            let current_thread_id = test::black_box(std::thread::current().id());
+            assert_eq!(current_thread_id, main_thread_id);
+        });
+    }
+}

--- a/main/high/src/log_util.rs
+++ b/main/high/src/log_util.rs
@@ -1,4 +1,3 @@
-
 use slog::{error, o, Drain};
 use std::backtrace::Backtrace;
 

--- a/main/high/src/log_util.rs
+++ b/main/high/src/log_util.rs
@@ -1,4 +1,4 @@
-use crate::Reaper;
+
 use slog::{error, o, Drain};
 use std::backtrace::Backtrace;
 

--- a/main/high/src/midi_input_device.rs
+++ b/main/high/src/midi_input_device.rs
@@ -1,4 +1,3 @@
-
 use reaper_medium::{MidiInputDeviceId, ReaperFunctions};
 use std::ffi::CString;
 

--- a/main/high/src/midi_input_device.rs
+++ b/main/high/src/midi_input_device.rs
@@ -1,5 +1,5 @@
 use crate::Reaper;
-use reaper_medium::MidiInputDeviceId;
+use reaper_medium::{MidiInputDeviceId, ReaperFunctions};
 use std::ffi::CString;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -17,9 +17,7 @@ impl MidiInputDevice {
     }
 
     pub fn get_name(self) -> CString {
-        Reaper::get()
-            .medium()
-            .functions()
+        ReaperFunctions::get()
             .get_midi_input_name(self.id, 33)
             .name
             .unwrap()
@@ -28,19 +26,14 @@ impl MidiInputDevice {
     // For REAPER < 5.94 this is the same like isConnected(). For REAPER >=5.94 it returns true if
     // the device ever existed, even if it's disconnected now.
     pub fn is_available(self) -> bool {
-        let result = Reaper::get()
-            .medium()
-            .functions()
-            .get_midi_input_name(self.id, 2);
+        let result = ReaperFunctions::get().get_midi_input_name(self.id, 2);
         result.is_present || result.name.is_some()
     }
 
     // Only returns true if the device is connected (= present)
     pub fn is_connected(self) -> bool {
         // In REAPER 5.94 GetMIDIInputName doesn't accept nullptr as name buffer on OS X
-        Reaper::get()
-            .medium()
-            .functions()
+        ReaperFunctions::get()
             .get_midi_input_name(self.id, 1)
             .is_present
     }

--- a/main/high/src/midi_input_device.rs
+++ b/main/high/src/midi_input_device.rs
@@ -1,4 +1,4 @@
-use crate::Reaper;
+
 use reaper_medium::{MidiInputDeviceId, ReaperFunctions};
 use std::ffi::CString;
 

--- a/main/high/src/midi_output_device.rs
+++ b/main/high/src/midi_output_device.rs
@@ -1,4 +1,4 @@
-use crate::Reaper;
+
 use reaper_medium::{MidiOutputDeviceId, ReaperFunctions};
 use std::ffi::CString;
 

--- a/main/high/src/midi_output_device.rs
+++ b/main/high/src/midi_output_device.rs
@@ -1,4 +1,3 @@
-
 use reaper_medium::{MidiOutputDeviceId, ReaperFunctions};
 use std::ffi::CString;
 

--- a/main/high/src/midi_output_device.rs
+++ b/main/high/src/midi_output_device.rs
@@ -1,5 +1,5 @@
 use crate::Reaper;
-use reaper_medium::MidiOutputDeviceId;
+use reaper_medium::{MidiOutputDeviceId, ReaperFunctions};
 use std::ffi::CString;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -17,9 +17,7 @@ impl MidiOutputDevice {
     }
 
     pub fn get_name(self) -> CString {
-        Reaper::get()
-            .medium()
-            .functions()
+        ReaperFunctions::get()
             .get_midi_output_name(self.id, 33)
             .name
             .unwrap()
@@ -28,19 +26,14 @@ impl MidiOutputDevice {
     // For REAPER < 5.94 this is the same like isConnected(). For REAPER >=5.94 it returns true if
     // the device ever existed, even if it's disconnected now.
     pub fn is_available(self) -> bool {
-        let result = Reaper::get()
-            .medium()
-            .functions()
-            .get_midi_output_name(self.id, 2);
+        let result = ReaperFunctions::get().get_midi_output_name(self.id, 2);
         result.is_present || result.name.is_some()
     }
 
     // Only returns true if the device is connected (= present)
     pub fn is_connected(self) -> bool {
         // In REAPER 5.94 GetMIDIOutputName doesn't accept nullptr as name buffer on OS X
-        Reaper::get()
-            .medium()
-            .functions()
+        ReaperFunctions::get()
             .get_midi_output_name(self.id, 1)
             .is_present
     }

--- a/main/high/src/project.rs
+++ b/main/high/src/project.rs
@@ -5,7 +5,8 @@ use crate::{Reaper, Tempo, Track};
 
 use reaper_medium::ProjectContext::{CurrentProject, Proj};
 use reaper_medium::{
-    MasterTrackBehavior, ProjectRef, ReaProject, TrackDefaultsBehavior, TrackRef, UndoBehavior,
+    MasterTrackBehavior, ProjectRef, ReaProject, ReaperFunctions, TrackDefaultsBehavior, TrackRef,
+    UndoBehavior,
 };
 use std::path::PathBuf;
 
@@ -28,9 +29,7 @@ impl Project {
     }
 
     pub fn get_file_path(self) -> Option<PathBuf> {
-        Reaper::get()
-            .medium()
-            .functions()
+        ReaperFunctions::get()
             .enum_projects(ProjectRef::Tab(self.get_index()), 5000)
             .unwrap()
             .file_path
@@ -53,10 +52,7 @@ impl Project {
     /// track (master track is not obtainable via this method).
     pub fn get_track_by_index(self, idx: u32) -> Option<Track> {
         self.complain_if_not_available();
-        let media_track = Reaper::get()
-            .medium()
-            .functions()
-            .get_track(Proj(self.rea_project), idx)?;
+        let media_track = ReaperFunctions::get().get_track(Proj(self.rea_project), idx)?;
         Some(Track::new(media_track, Some(self.rea_project)))
     }
 
@@ -79,9 +75,7 @@ impl Project {
     pub fn get_tracks(self) -> impl Iterator<Item = Track> + 'static {
         self.complain_if_not_available();
         (0..self.get_track_count()).map(move |i| {
-            let media_track = Reaper::get()
-                .medium()
-                .functions()
+            let media_track = ReaperFunctions::get()
                 .get_track(Proj(self.rea_project), i)
                 .unwrap();
             Track::new(media_track, Some(self.rea_project))
@@ -89,35 +83,23 @@ impl Project {
     }
 
     pub fn is_available(self) -> bool {
-        Reaper::get()
-            .medium()
-            .functions()
-            .validate_ptr_2(CurrentProject, self.rea_project)
+        ReaperFunctions::get().validate_ptr_2(CurrentProject, self.rea_project)
     }
 
     pub fn get_selected_track_count(self, want_master: MasterTrackBehavior) -> u32 {
-        Reaper::get()
-            .medium()
-            .functions()
-            .count_selected_tracks_2(Proj(self.rea_project), want_master) as u32
+        ReaperFunctions::get().count_selected_tracks_2(Proj(self.rea_project), want_master) as u32
     }
 
     pub fn get_first_selected_track(self, want_master: MasterTrackBehavior) -> Option<Track> {
-        let media_track = Reaper::get().medium().functions().get_selected_track_2(
-            Proj(self.rea_project),
-            0,
-            want_master,
-        )?;
+        let media_track =
+            ReaperFunctions::get().get_selected_track_2(Proj(self.rea_project), 0, want_master)?;
         Some(Track::new(media_track, Some(self.rea_project)))
     }
 
     pub fn unselect_all_tracks(self) {
         // TODO-low No project context
         unsafe {
-            Reaper::get()
-                .medium()
-                .functions()
-                .set_only_track_selected(None);
+            ReaperFunctions::get().set_only_track_selected(None);
         }
     }
 
@@ -127,9 +109,7 @@ impl Project {
     ) -> impl Iterator<Item = Track> + 'static {
         self.complain_if_not_available();
         (0..self.get_selected_track_count(want_master)).map(move |i| {
-            let media_track = Reaper::get()
-                .medium()
-                .functions()
+            let media_track = ReaperFunctions::get()
                 .get_selected_track_2(Proj(self.rea_project), i, want_master)
                 .unwrap();
             Track::new(media_track, Some(self.rea_project))
@@ -138,10 +118,7 @@ impl Project {
 
     pub fn get_track_count(self) -> u32 {
         self.complain_if_not_available();
-        Reaper::get()
-            .medium()
-            .functions()
-            .count_tracks(Proj(self.rea_project)) as u32
+        ReaperFunctions::get().count_tracks(Proj(self.rea_project)) as u32
     }
 
     // TODO-low Introduce variant that doesn't notify ControlSurface
@@ -152,10 +129,7 @@ impl Project {
 
     pub fn remove_track(self, track: &Track) {
         unsafe {
-            Reaper::get()
-                .medium()
-                .functions()
-                .delete_track(track.get_raw());
+            ReaperFunctions::get().delete_track(track.get_raw());
         }
     }
 
@@ -163,29 +137,16 @@ impl Project {
     pub fn insert_track_at(self, index: u32) -> Track {
         self.complain_if_not_available();
         // TODO-low reaper::InsertTrackAtIndex unfortunately doesn't allow to specify ReaProject :(
-        let reaper = Reaper::get();
-        reaper
-            .medium()
-            .functions()
-            .insert_track_at_index(index, TrackDefaultsBehavior::OmitDefaultEnvAndFx);
-        reaper
-            .medium()
-            .functions()
-            .track_list_update_all_external_surfaces();
-        let media_track = reaper
-            .medium()
-            .functions()
-            .get_track(Proj(self.rea_project), index)
-            .unwrap();
+        let functions = ReaperFunctions::get();
+        functions.insert_track_at_index(index, TrackDefaultsBehavior::OmitDefaultEnvAndFx);
+        functions.track_list_update_all_external_surfaces();
+        let media_track = functions.get_track(Proj(self.rea_project), index).unwrap();
         Track::new(media_track, Some(self.rea_project))
     }
 
     pub fn get_master_track(self) -> Track {
         self.complain_if_not_available();
-        let mt = Reaper::get()
-            .medium()
-            .functions()
-            .get_master_track(Proj(self.rea_project));
+        let mt = ReaperFunctions::get().get_master_track(Proj(self.rea_project));
         Track::new(mt, Some(self.rea_project))
     }
 
@@ -204,62 +165,40 @@ impl Project {
 
     pub fn undo(self) -> bool {
         self.complain_if_not_available();
-        Reaper::get()
-            .medium()
-            .functions()
-            .undo_do_undo_2(Proj(self.rea_project))
+        ReaperFunctions::get().undo_do_undo_2(Proj(self.rea_project))
     }
 
     pub fn redo(self) -> bool {
-        Reaper::get()
-            .medium()
-            .functions()
-            .undo_do_redo_2(Proj(self.rea_project))
+        ReaperFunctions::get().undo_do_redo_2(Proj(self.rea_project))
     }
 
     pub fn mark_as_dirty(self) {
-        Reaper::get()
-            .medium()
-            .functions()
-            .mark_project_dirty(Proj(self.rea_project));
+        ReaperFunctions::get().mark_project_dirty(Proj(self.rea_project));
     }
 
     pub fn is_dirty(self) -> bool {
-        Reaper::get()
-            .medium()
-            .functions()
-            .is_project_dirty(Proj(self.rea_project))
+        ReaperFunctions::get().is_project_dirty(Proj(self.rea_project))
     }
 
     pub fn get_label_of_last_undoable_action(self) -> Option<CString> {
         self.complain_if_not_available();
-        Reaper::get()
-            .medium()
-            .functions()
-            .undo_can_undo_2(Proj(self.rea_project), |s| s.into())
+        ReaperFunctions::get().undo_can_undo_2(Proj(self.rea_project), |s| s.into())
     }
 
     pub fn get_label_of_last_redoable_action(self) -> Option<CString> {
         self.complain_if_not_available();
-        Reaper::get()
-            .medium()
-            .functions()
-            .undo_can_redo_2(Proj(self.rea_project), |s| s.into())
+        ReaperFunctions::get().undo_can_redo_2(Proj(self.rea_project), |s| s.into())
     }
 
     pub fn get_tempo(self) -> Tempo {
         // TODO This is not project-specific ... why?
-        let bpm = Reaper::get().medium().functions().master_get_tempo();
+        let bpm = ReaperFunctions::get().master_get_tempo();
         Tempo::from_bpm(bpm)
     }
 
     pub fn set_tempo(self, tempo: Tempo, undo_hint: UndoBehavior) {
         self.complain_if_not_available();
-        Reaper::get().medium().functions().set_current_bpm(
-            Proj(self.rea_project),
-            tempo.get_bpm(),
-            undo_hint,
-        );
+        ReaperFunctions::get().set_current_bpm(Proj(self.rea_project), tempo.get_bpm(), undo_hint);
     }
 
     fn complain_if_not_available(self) {

--- a/main/high/src/reaper.rs
+++ b/main/high/src/reaper.rs
@@ -400,6 +400,13 @@ impl Reaper {
             unsafe { REAPER_INSTANCE.borrow().is_none() },
             "There's a Reaper instance already"
         );
+        // TODO Making available this object globally is maybe not the best way. In most places,
+        //  only the functions are needed, not the extra stuff (subjects, channels etc.) which
+        //  requires interior mutability. Handle this.
+        // For now, we set up a medium-level Reaper instance and use this wherever possible, in
+        // order to get a feeling in which places we really need the full high-level Reaper
+        // instance.
+        reaper_medium::ReaperFunctions::make_available_globally(medium.functions().clone());
         let reaper = Reaper {
             medium: RefCell::new(medium),
             logger,
@@ -564,7 +571,7 @@ impl Reaper {
     }
 
     pub fn generate_guid(&self) -> Guid {
-        Guid::new(Reaper::get().medium().functions().gen_guid())
+        Guid::new(ReaperFunctions::get().gen_guid())
     }
 
     pub fn register_action(

--- a/main/high/src/section.rs
+++ b/main/high/src/section.rs
@@ -1,4 +1,4 @@
-use crate::{Action, Reaper};
+use crate::{Action};
 use reaper_medium::{CommandId, KbdSectionInfo, ReaperFunctions, SectionId};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/main/high/src/section.rs
+++ b/main/high/src/section.rs
@@ -1,4 +1,4 @@
-use crate::{Action};
+use crate::Action;
 use reaper_medium::{CommandId, KbdSectionInfo, ReaperFunctions, SectionId};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/main/high/src/section.rs
+++ b/main/high/src/section.rs
@@ -1,5 +1,5 @@
 use crate::{Action, Reaper};
-use reaper_medium::{CommandId, KbdSectionInfo, SectionId};
+use reaper_medium::{CommandId, KbdSectionInfo, ReaperFunctions, SectionId};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Section {
@@ -16,19 +16,14 @@ impl Section {
     }
 
     pub fn with_raw<R>(self, f: impl FnOnce(&KbdSectionInfo) -> R) -> Option<R> {
-        Reaper::get()
-            .medium()
-            .functions()
-            .section_from_unique_id(self.id, f)
+        ReaperFunctions::get().section_from_unique_id(self.id, f)
     }
 
     /// # Safety
     ///
     /// The lifetime of the returned section is unbounded.
     pub unsafe fn get_raw(self) -> KbdSectionInfo {
-        Reaper::get()
-            .medium()
-            .functions()
+        ReaperFunctions::get()
             .section_from_unique_id_unchecked(self.id)
             .unwrap()
     }
@@ -57,9 +52,7 @@ impl Section {
     ///
     /// Unsafe because at the time when the iterator is evaluated, the section could be gone.
     pub unsafe fn get_actions(self) -> impl Iterator<Item = Action> + 'static {
-        let sec = Reaper::get()
-            .medium()
-            .functions()
+        let sec = ReaperFunctions::get()
             .section_from_unique_id_unchecked(self.id)
             .unwrap();
         (0..sec.action_list_cnt()).map(move |i| {

--- a/main/high/src/track.rs
+++ b/main/high/src/track.rs
@@ -19,7 +19,11 @@ use reaper_medium::ProjectContext::Proj;
 use reaper_medium::SendTarget::OtherTrack;
 use reaper_medium::TrackAttributeKey::{Mute, Name, RecArm, RecInput, RecMon, Selected, Solo};
 use reaper_medium::ValueChange::Absolute;
-use reaper_medium::{AutomationMode, ChunkCacheHint, GangBehavior, GlobalAutomationModeOverride, InputMonitoringMode, MediaTrack, ReaProject, RecordArmMode, RecordingInput, TrackRef, TrackSendCategory, ReaperFunctions};
+use reaper_medium::{
+    AutomationMode, ChunkCacheHint, GangBehavior, GlobalAutomationModeOverride,
+    InputMonitoringMode, MediaTrack, ReaProject, ReaperFunctions, RecordArmMode, RecordingInput,
+    TrackRef, TrackSendCategory,
+};
 
 pub const MAX_TRACK_CHUNK_SIZE: u32 = 1_000_000;
 
@@ -85,31 +89,30 @@ impl Track {
     pub fn get_name(&self) -> CString {
         self.load_and_check_if_necessary_or_complain();
         unsafe {
-            ReaperFunctions::get()
-                .get_set_media_track_info_get_name(self.get_raw(), |n| n.into())
+            ReaperFunctions::get().get_set_media_track_info_get_name(self.get_raw(), |n| n.into())
         }
         .unwrap_or_else(|| c_str!("<Master track>").to_owned())
     }
 
     pub fn get_input_monitoring_mode(&self) -> InputMonitoringMode {
         self.load_and_check_if_necessary_or_complain();
-        unsafe {
-            ReaperFunctions::get()                .get_set_media_track_info_get_rec_mon(self.get_raw())
-        }
+        unsafe { ReaperFunctions::get().get_set_media_track_info_get_rec_mon(self.get_raw()) }
     }
 
     pub fn set_input_monitoring_mode(&self, mode: InputMonitoringMode) {
         self.load_and_check_if_necessary_or_complain();
         unsafe {
-            ReaperFunctions::get()                .csurf_on_input_monitoring_change_ex(self.get_raw(), mode, GangBehavior::DenyGang);
+            ReaperFunctions::get().csurf_on_input_monitoring_change_ex(
+                self.get_raw(),
+                mode,
+                GangBehavior::DenyGang,
+            );
         }
     }
 
     pub fn get_recording_input(&self) -> Option<RecordingInput> {
         self.load_and_check_if_necessary_or_complain();
-        unsafe {
-            ReaperFunctions::get()                .get_set_media_track_info_get_rec_input(self.get_raw())
-        }
+        unsafe { ReaperFunctions::get().get_set_media_track_info_get_rec_input(self.get_raw()) }
     }
 
     pub fn set_recording_input(&self, input: Option<RecordingInput>) {
@@ -128,9 +131,8 @@ impl Track {
         // Only for triggering notification (as manual setting the rec input would also trigger it)
         // This doesn't work for other surfaces but they are also not interested in record input
         // changes.
-        let _rec_mon = unsafe {
-            ReaperFunctions::get()                .get_media_track_info_value(self.get_raw(), RecMon)
-        };
+        let _rec_mon =
+            unsafe { ReaperFunctions::get().get_media_track_info_value(self.get_raw(), RecMon) };
         // TODO-low 5198273 This is ugly. Solve in other ways.
         // let control_surface = get_control_surface_instance();
         // let super_raw: *mut raw::MediaTrack = self.get_raw().as_ptr();
@@ -151,10 +153,8 @@ impl Track {
         self.load_and_check_if_necessary_or_complain();
         // It's important that we don't query D_PAN because that returns the wrong value in case an
         // envelope is written
-        let result = unsafe {
-            ReaperFunctions::get()                .get_track_ui_vol_pan(self.get_raw())
-        }
-        .expect("Couldn't get vol/pan");
+        let result = unsafe { ReaperFunctions::get().get_track_ui_vol_pan(self.get_raw()) }
+            .expect("Couldn't get vol/pan");
         Pan::from_reaper_value(result.pan)
     }
 
@@ -171,21 +171,15 @@ impl Track {
         // Setting the pan programmatically doesn't trigger SetSurfacePan in HelperControlSurface so
         // we need to notify manually
         unsafe {
-            ReaperFunctions::get().csurf_set_surface_pan(
-                self.get_raw(),
-                reaper_value,
-                NotifyAll,
-            );
+            ReaperFunctions::get().csurf_set_surface_pan(self.get_raw(), reaper_value, NotifyAll);
         }
     }
 
     pub fn get_volume(&self) -> Volume {
         // It's important that we don't query D_VOL because that returns the wrong value in case an
         // envelope is written
-        let result = unsafe {
-            ReaperFunctions::get()                .get_track_ui_vol_pan(self.get_raw())
-        }
-        .expect("Couldn't get vol/pan");
+        let result = unsafe { ReaperFunctions::get().get_track_ui_vol_pan(self.get_raw()) }
+            .expect("Couldn't get vol/pan");
         Volume::from_reaper_value(result.volume)
     }
 
@@ -218,7 +212,7 @@ impl Track {
         // TODO-low The following returns None if we query the number of a track in another project
         //  Try to find a working solution!
         let result = unsafe {
-            ReaperFunctions::get()                .get_set_media_track_info_get_track_number(self.get_raw())
+            ReaperFunctions::get().get_set_media_track_info_get_track_number(self.get_raw())
         }?;
         use TrackRef::*;
         match result {
@@ -239,7 +233,7 @@ impl Track {
         } else {
             self.load_and_check_if_necessary_or_complain();
             let recarm = unsafe {
-                ReaperFunctions::get()                    .get_media_track_info_value(self.get_raw(), RecArm)
+                ReaperFunctions::get().get_media_track_info_value(self.get_raw(), RecArm)
             };
             recarm == 1.0
         }
@@ -261,7 +255,7 @@ impl Track {
             // not actually armed the track. Therefore we check if it's really armed and
             // if not we do it again.
             let recarm = unsafe {
-                ReaperFunctions::get()                    .get_media_track_info_value(self.get_raw(), RecArm)
+                ReaperFunctions::get().get_media_track_info_value(self.get_raw(), RecArm)
             };
             #[allow(clippy::float_cmp)]
             if recarm != 1.0 {
@@ -282,11 +276,11 @@ impl Track {
             self.unselect();
         } else {
             unsafe {
-                ReaperFunctions::get()                    .csurf_on_rec_arm_change_ex(
-                        self.get_raw(),
-                        RecordArmMode::Unarmed,
-                        GangBehavior::DenyGang,
-                    );
+                ReaperFunctions::get().csurf_on_rec_arm_change_ex(
+                    self.get_raw(),
+                    RecordArmMode::Unarmed,
+                    GangBehavior::DenyGang,
+                );
             }
         }
     }
@@ -322,57 +316,51 @@ impl Track {
     #[allow(clippy::float_cmp)]
     pub fn is_muted(&self) -> bool {
         self.load_and_check_if_necessary_or_complain();
-        let mute = unsafe {
-            ReaperFunctions::get()                .get_media_track_info_value(self.get_raw(), Mute)
-        };
+        let mute =
+            unsafe { ReaperFunctions::get().get_media_track_info_value(self.get_raw(), Mute) };
         mute == 1.0
     }
 
     pub fn mute(&self) {
         self.load_and_check_if_necessary_or_complain();
-        let _ = unsafe {
-            ReaperFunctions::get()                .set_media_track_info_value(self.get_raw(), Mute, 1.0)
-        };
+        let _ =
+            unsafe { ReaperFunctions::get().set_media_track_info_value(self.get_raw(), Mute, 1.0) };
         unsafe {
-            ReaperFunctions::get()                .csurf_set_surface_mute(self.get_raw(), true, NotifyAll);
+            ReaperFunctions::get().csurf_set_surface_mute(self.get_raw(), true, NotifyAll);
         }
     }
 
     pub fn unmute(&self) {
         self.load_and_check_if_necessary_or_complain();
-        let _ = unsafe {
-            ReaperFunctions::get()                .set_media_track_info_value(self.get_raw(), Mute, 0.0)
-        };
+        let _ =
+            unsafe { ReaperFunctions::get().set_media_track_info_value(self.get_raw(), Mute, 0.0) };
         unsafe {
-            ReaperFunctions::get()                .csurf_set_surface_mute(self.get_raw(), false, NotifyAll);
+            ReaperFunctions::get().csurf_set_surface_mute(self.get_raw(), false, NotifyAll);
         }
     }
 
     pub fn is_solo(&self) -> bool {
         self.load_and_check_if_necessary_or_complain();
-        let solo = unsafe {
-            ReaperFunctions::get()                .get_media_track_info_value(self.get_raw(), Solo)
-        };
+        let solo =
+            unsafe { ReaperFunctions::get().get_media_track_info_value(self.get_raw(), Solo) };
         solo > 0.0
     }
 
     pub fn solo(&self) {
         self.load_and_check_if_necessary_or_complain();
-        let _ = unsafe {
-            ReaperFunctions::get()                .set_media_track_info_value(self.get_raw(), Solo, 1.0)
-        };
+        let _ =
+            unsafe { ReaperFunctions::get().set_media_track_info_value(self.get_raw(), Solo, 1.0) };
         unsafe {
-            ReaperFunctions::get()                .csurf_set_surface_solo(self.get_raw(), true, NotifyAll);
+            ReaperFunctions::get().csurf_set_surface_solo(self.get_raw(), true, NotifyAll);
         }
     }
 
     pub fn unsolo(&self) {
         self.load_and_check_if_necessary_or_complain();
-        let _ = unsafe {
-            ReaperFunctions::get()                .set_media_track_info_value(self.get_raw(), Solo, 0.0)
-        };
+        let _ =
+            unsafe { ReaperFunctions::get().set_media_track_info_value(self.get_raw(), Solo, 0.0) };
         unsafe {
-            ReaperFunctions::get()                .csurf_set_surface_solo(self.get_raw(), false, NotifyAll);
+            ReaperFunctions::get().csurf_set_surface_solo(self.get_raw(), false, NotifyAll);
         }
     }
 
@@ -410,44 +398,44 @@ impl Track {
     #[allow(clippy::float_cmp)]
     pub fn is_selected(&self) -> bool {
         self.load_and_check_if_necessary_or_complain();
-        let selected = unsafe {
-            ReaperFunctions::get()                .get_media_track_info_value(self.get_raw(), Selected)
-        };
+        let selected =
+            unsafe { ReaperFunctions::get().get_media_track_info_value(self.get_raw(), Selected) };
         selected == 1.0
     }
 
     pub fn select(&self) {
         self.load_and_check_if_necessary_or_complain();
         unsafe {
-            ReaperFunctions::get()                .set_track_selected(self.get_raw(), true);
+            ReaperFunctions::get().set_track_selected(self.get_raw(), true);
         }
     }
 
     pub fn select_exclusively(&self) {
         self.load_and_check_if_necessary_or_complain();
         unsafe {
-            ReaperFunctions::get()                .set_only_track_selected(Some(self.get_raw()));
+            ReaperFunctions::get().set_only_track_selected(Some(self.get_raw()));
         }
     }
 
     pub fn unselect(&self) {
         self.load_and_check_if_necessary_or_complain();
         unsafe {
-            ReaperFunctions::get()                .set_track_selected(self.get_raw(), false);
+            ReaperFunctions::get().set_track_selected(self.get_raw(), false);
         }
     }
 
     pub fn get_send_count(&self) -> u32 {
         self.load_and_check_if_necessary_or_complain();
         unsafe {
-            ReaperFunctions::get()                .get_track_num_sends(self.get_raw(), TrackSendCategory::Send)
+            ReaperFunctions::get().get_track_num_sends(self.get_raw(), TrackSendCategory::Send)
         }
     }
 
     pub fn add_send_to(&self, target_track: Track) -> TrackSend {
         // TODO-low Check how this behaves if send already exists
         let send_index = unsafe {
-            ReaperFunctions::get()                .create_track_send(self.get_raw(), OtherTrack(target_track.get_raw()))
+            ReaperFunctions::get()
+                .create_track_send(self.get_raw(), OtherTrack(target_track.get_raw()))
         }
         .unwrap();
         TrackSend::target_based(self.clone(), target_track, Some(send_index))
@@ -526,7 +514,7 @@ impl Track {
             None => false,
             Some(rea_project) => {
                 if Project::new(rea_project).is_available() {
-                    ReaperFunctions::get()                        .validate_ptr_2(Proj(rea_project), media_track)
+                    ReaperFunctions::get().validate_ptr_2(Proj(rea_project), media_track)
                 } else {
                     false
                 }
@@ -615,9 +603,7 @@ impl Track {
 
     pub fn get_automation_mode(&self) -> AutomationMode {
         self.load_and_check_if_necessary_or_complain();
-        unsafe {
-            ReaperFunctions::get()                .get_track_automation_mode(self.media_track.get().unwrap())
-        }
+        unsafe { ReaperFunctions::get().get_track_automation_mode(self.media_track.get().unwrap()) }
     }
 
     // None means Bypass
@@ -641,7 +627,7 @@ impl Track {
     pub fn is_master_track(&self) -> bool {
         self.load_and_check_if_necessary_or_complain();
         let t = unsafe {
-            ReaperFunctions::get()                .get_set_media_track_info_get_track_number(self.get_raw())
+            ReaperFunctions::get().get_set_media_track_info_get_track_number(self.get_raw())
         };
         t == Some(TrackRef::MasterTrack)
     }
@@ -666,18 +652,14 @@ impl PartialEq for Track {
 }
 
 pub fn get_media_track_guid(media_track: MediaTrack) -> Guid {
-    let internal = unsafe {
-        ReaperFunctions::get()            .get_set_media_track_info_get_guid(media_track)
-    };
+    let internal = unsafe { ReaperFunctions::get().get_set_media_track_info_get_guid(media_track) };
     Guid::new(internal)
 }
 
 // In REAPER < 5.95 this returns nullptr. That means we might need to use findContainingProject
 // logic at a later point.
 fn get_track_project_raw(media_track: MediaTrack) -> Option<ReaProject> {
-    unsafe {
-        ReaperFunctions::get()            .get_set_media_track_info_get_project(media_track)
-    }
+    unsafe { ReaperFunctions::get().get_set_media_track_info_get_project(media_track) }
 }
 
 fn get_auto_arm_chunk_line(chunk: &Chunk) -> Option<ChunkRegion> {

--- a/main/high/src/track.rs
+++ b/main/high/src/track.rs
@@ -19,11 +19,7 @@ use reaper_medium::ProjectContext::Proj;
 use reaper_medium::SendTarget::OtherTrack;
 use reaper_medium::TrackAttributeKey::{Mute, Name, RecArm, RecInput, RecMon, Selected, Solo};
 use reaper_medium::ValueChange::Absolute;
-use reaper_medium::{
-    AutomationMode, ChunkCacheHint, GangBehavior, GlobalAutomationModeOverride,
-    InputMonitoringMode, MediaTrack, ReaProject, RecordArmMode, RecordingInput, TrackRef,
-    TrackSendCategory,
-};
+use reaper_medium::{AutomationMode, ChunkCacheHint, GangBehavior, GlobalAutomationModeOverride, InputMonitoringMode, MediaTrack, ReaProject, RecordArmMode, RecordingInput, TrackRef, TrackSendCategory, ReaperFunctions};
 
 pub const MAX_TRACK_CHUNK_SIZE: u32 = 1_000_000;
 
@@ -77,7 +73,7 @@ impl Track {
     pub fn set_name(&self, name: &CStr) {
         self.load_and_check_if_necessary_or_complain();
         unsafe {
-            Reaper::get().medium().functions().get_set_media_track_info(
+            ReaperFunctions::get().get_set_media_track_info(
                 self.get_raw(),
                 Name,
                 name.as_ptr() as *mut c_void,
@@ -89,9 +85,7 @@ impl Track {
     pub fn get_name(&self) -> CString {
         self.load_and_check_if_necessary_or_complain();
         unsafe {
-            Reaper::get()
-                .medium()
-                .functions()
+            ReaperFunctions::get()
                 .get_set_media_track_info_get_name(self.get_raw(), |n| n.into())
         }
         .unwrap_or_else(|| c_str!("<Master track>").to_owned())
@@ -100,30 +94,21 @@ impl Track {
     pub fn get_input_monitoring_mode(&self) -> InputMonitoringMode {
         self.load_and_check_if_necessary_or_complain();
         unsafe {
-            Reaper::get()
-                .medium()
-                .functions()
-                .get_set_media_track_info_get_rec_mon(self.get_raw())
+            ReaperFunctions::get()                .get_set_media_track_info_get_rec_mon(self.get_raw())
         }
     }
 
     pub fn set_input_monitoring_mode(&self, mode: InputMonitoringMode) {
         self.load_and_check_if_necessary_or_complain();
         unsafe {
-            Reaper::get()
-                .medium()
-                .functions()
-                .csurf_on_input_monitoring_change_ex(self.get_raw(), mode, GangBehavior::DenyGang);
+            ReaperFunctions::get()                .csurf_on_input_monitoring_change_ex(self.get_raw(), mode, GangBehavior::DenyGang);
         }
     }
 
     pub fn get_recording_input(&self) -> Option<RecordingInput> {
         self.load_and_check_if_necessary_or_complain();
         unsafe {
-            Reaper::get()
-                .medium()
-                .functions()
-                .get_set_media_track_info_get_rec_input(self.get_raw())
+            ReaperFunctions::get()                .get_set_media_track_info_get_rec_input(self.get_raw())
         }
     }
 
@@ -133,9 +118,8 @@ impl Track {
             None => -1,
             Some(ri) => ri.to_raw(),
         };
-        let reaper = Reaper::get();
         let _ = unsafe {
-            reaper.medium().functions().set_media_track_info_value(
+            ReaperFunctions::get().set_media_track_info_value(
                 self.get_raw(),
                 RecInput,
                 rec_input_index as f64,
@@ -145,10 +129,7 @@ impl Track {
         // This doesn't work for other surfaces but they are also not interested in record input
         // changes.
         let _rec_mon = unsafe {
-            reaper
-                .medium()
-                .functions()
-                .get_media_track_info_value(self.get_raw(), RecMon)
+            ReaperFunctions::get()                .get_media_track_info_value(self.get_raw(), RecMon)
         };
         // TODO-low 5198273 This is ugly. Solve in other ways.
         // let control_surface = get_control_surface_instance();
@@ -171,10 +152,7 @@ impl Track {
         // It's important that we don't query D_PAN because that returns the wrong value in case an
         // envelope is written
         let result = unsafe {
-            Reaper::get()
-                .medium()
-                .functions()
-                .get_track_ui_vol_pan(self.get_raw())
+            ReaperFunctions::get()                .get_track_ui_vol_pan(self.get_raw())
         }
         .expect("Couldn't get vol/pan");
         Pan::from_reaper_value(result.pan)
@@ -183,9 +161,8 @@ impl Track {
     pub fn set_pan(&self, pan: Pan) {
         self.load_and_check_if_necessary_or_complain();
         let reaper_value = pan.get_reaper_value();
-        let reaper = Reaper::get();
         unsafe {
-            reaper.medium().functions().csurf_on_pan_change_ex(
+            ReaperFunctions::get().csurf_on_pan_change_ex(
                 self.get_raw(),
                 Absolute(reaper_value),
                 GangBehavior::DenyGang,
@@ -194,7 +171,7 @@ impl Track {
         // Setting the pan programmatically doesn't trigger SetSurfacePan in HelperControlSurface so
         // we need to notify manually
         unsafe {
-            reaper.medium().functions().csurf_set_surface_pan(
+            ReaperFunctions::get().csurf_set_surface_pan(
                 self.get_raw(),
                 reaper_value,
                 NotifyAll,
@@ -206,10 +183,7 @@ impl Track {
         // It's important that we don't query D_VOL because that returns the wrong value in case an
         // envelope is written
         let result = unsafe {
-            Reaper::get()
-                .medium()
-                .functions()
-                .get_track_ui_vol_pan(self.get_raw())
+            ReaperFunctions::get()                .get_track_ui_vol_pan(self.get_raw())
         }
         .expect("Couldn't get vol/pan");
         Volume::from_reaper_value(result.volume)
@@ -218,12 +192,11 @@ impl Track {
     pub fn set_volume(&self, volume: Volume) {
         self.load_and_check_if_necessary_or_complain();
         let reaper_value = volume.get_reaper_value();
-        let reaper = Reaper::get();
         // CSurf_OnVolumeChangeEx has a slightly lower precision than setting D_VOL directly. The
         // return value reflects the cropped value. The precision became much better with
         // REAPER 5.28.
         unsafe {
-            reaper.medium().functions().csurf_on_volume_change_ex(
+            ReaperFunctions::get().csurf_on_volume_change_ex(
                 self.get_raw(),
                 Absolute(reaper_value),
                 GangBehavior::DenyGang,
@@ -232,7 +205,7 @@ impl Track {
         // Setting the volume programmatically doesn't trigger SetSurfaceVolume in
         // HelperControlSurface so we need to notify manually
         unsafe {
-            reaper.medium().functions().csurf_set_surface_volume(
+            ReaperFunctions::get().csurf_set_surface_volume(
                 self.get_raw(),
                 reaper_value,
                 NotifyAll,
@@ -245,10 +218,7 @@ impl Track {
         // TODO-low The following returns None if we query the number of a track in another project
         //  Try to find a working solution!
         let result = unsafe {
-            Reaper::get()
-                .medium()
-                .functions()
-                .get_set_media_track_info_get_track_number(self.get_raw())
+            ReaperFunctions::get()                .get_set_media_track_info_get_track_number(self.get_raw())
         }?;
         use TrackRef::*;
         match result {
@@ -269,10 +239,7 @@ impl Track {
         } else {
             self.load_and_check_if_necessary_or_complain();
             let recarm = unsafe {
-                Reaper::get()
-                    .medium()
-                    .functions()
-                    .get_media_track_info_value(self.get_raw(), RecArm)
+                ReaperFunctions::get()                    .get_media_track_info_value(self.get_raw(), RecArm)
             };
             recarm == 1.0
         }
@@ -283,9 +250,8 @@ impl Track {
         if support_auto_arm && self.has_auto_arm_enabled() {
             self.select();
         } else {
-            let reaper = Reaper::get();
             unsafe {
-                reaper.medium().functions().csurf_on_rec_arm_change_ex(
+                ReaperFunctions::get().csurf_on_rec_arm_change_ex(
                     self.get_raw(),
                     RecordArmMode::Armed,
                     GangBehavior::DenyGang,
@@ -295,15 +261,12 @@ impl Track {
             // not actually armed the track. Therefore we check if it's really armed and
             // if not we do it again.
             let recarm = unsafe {
-                reaper
-                    .medium()
-                    .functions()
-                    .get_media_track_info_value(self.get_raw(), RecArm)
+                ReaperFunctions::get()                    .get_media_track_info_value(self.get_raw(), RecArm)
             };
             #[allow(clippy::float_cmp)]
             if recarm != 1.0 {
                 unsafe {
-                    reaper.medium().functions().csurf_on_rec_arm_change_ex(
+                    ReaperFunctions::get().csurf_on_rec_arm_change_ex(
                         self.get_raw(),
                         RecordArmMode::Armed,
                         GangBehavior::DenyGang,
@@ -319,10 +282,7 @@ impl Track {
             self.unselect();
         } else {
             unsafe {
-                Reaper::get()
-                    .medium()
-                    .functions()
-                    .csurf_on_rec_arm_change_ex(
+                ReaperFunctions::get()                    .csurf_on_rec_arm_change_ex(
                         self.get_raw(),
                         RecordArmMode::Unarmed,
                         GangBehavior::DenyGang,
@@ -363,90 +323,56 @@ impl Track {
     pub fn is_muted(&self) -> bool {
         self.load_and_check_if_necessary_or_complain();
         let mute = unsafe {
-            Reaper::get()
-                .medium()
-                .functions()
-                .get_media_track_info_value(self.get_raw(), Mute)
+            ReaperFunctions::get()                .get_media_track_info_value(self.get_raw(), Mute)
         };
         mute == 1.0
     }
 
     pub fn mute(&self) {
         self.load_and_check_if_necessary_or_complain();
-        let reaper = Reaper::get();
         let _ = unsafe {
-            reaper
-                .medium()
-                .functions()
-                .set_media_track_info_value(self.get_raw(), Mute, 1.0)
+            ReaperFunctions::get()                .set_media_track_info_value(self.get_raw(), Mute, 1.0)
         };
         unsafe {
-            reaper
-                .medium()
-                .functions()
-                .csurf_set_surface_mute(self.get_raw(), true, NotifyAll);
+            ReaperFunctions::get()                .csurf_set_surface_mute(self.get_raw(), true, NotifyAll);
         }
     }
 
     pub fn unmute(&self) {
         self.load_and_check_if_necessary_or_complain();
-        let reaper = Reaper::get();
         let _ = unsafe {
-            reaper
-                .medium()
-                .functions()
-                .set_media_track_info_value(self.get_raw(), Mute, 0.0)
+            ReaperFunctions::get()                .set_media_track_info_value(self.get_raw(), Mute, 0.0)
         };
         unsafe {
-            reaper
-                .medium()
-                .functions()
-                .csurf_set_surface_mute(self.get_raw(), false, NotifyAll);
+            ReaperFunctions::get()                .csurf_set_surface_mute(self.get_raw(), false, NotifyAll);
         }
     }
 
     pub fn is_solo(&self) -> bool {
         self.load_and_check_if_necessary_or_complain();
         let solo = unsafe {
-            Reaper::get()
-                .medium()
-                .functions()
-                .get_media_track_info_value(self.get_raw(), Solo)
+            ReaperFunctions::get()                .get_media_track_info_value(self.get_raw(), Solo)
         };
         solo > 0.0
     }
 
     pub fn solo(&self) {
         self.load_and_check_if_necessary_or_complain();
-        let reaper = Reaper::get();
         let _ = unsafe {
-            reaper
-                .medium()
-                .functions()
-                .set_media_track_info_value(self.get_raw(), Solo, 1.0)
+            ReaperFunctions::get()                .set_media_track_info_value(self.get_raw(), Solo, 1.0)
         };
         unsafe {
-            reaper
-                .medium()
-                .functions()
-                .csurf_set_surface_solo(self.get_raw(), true, NotifyAll);
+            ReaperFunctions::get()                .csurf_set_surface_solo(self.get_raw(), true, NotifyAll);
         }
     }
 
     pub fn unsolo(&self) {
         self.load_and_check_if_necessary_or_complain();
-        let reaper = Reaper::get();
         let _ = unsafe {
-            reaper
-                .medium()
-                .functions()
-                .set_media_track_info_value(self.get_raw(), Solo, 0.0)
+            ReaperFunctions::get()                .set_media_track_info_value(self.get_raw(), Solo, 0.0)
         };
         unsafe {
-            reaper
-                .medium()
-                .functions()
-                .csurf_set_surface_solo(self.get_raw(), false, NotifyAll);
+            ReaperFunctions::get()                .csurf_set_surface_solo(self.get_raw(), false, NotifyAll);
         }
     }
 
@@ -459,7 +385,7 @@ impl Track {
     // should be double checked then.
     pub fn get_chunk(&self, max_chunk_size: u32, undo_is_optional: ChunkCacheHint) -> Chunk {
         let chunk_content = unsafe {
-            Reaper::get().medium().functions().get_track_state_chunk(
+            ReaperFunctions::get().get_track_state_chunk(
                 self.get_raw(),
                 max_chunk_size,
                 undo_is_optional,
@@ -473,7 +399,7 @@ impl Track {
     pub fn set_chunk(&self, chunk: Chunk) {
         let c_string: CString = chunk.into();
         let _ = unsafe {
-            Reaper::get().medium().functions().set_track_state_chunk(
+            ReaperFunctions::get().set_track_state_chunk(
                 self.get_raw(),
                 c_string.as_c_str(),
                 ChunkCacheHint::UndoMode,
@@ -485,10 +411,7 @@ impl Track {
     pub fn is_selected(&self) -> bool {
         self.load_and_check_if_necessary_or_complain();
         let selected = unsafe {
-            Reaper::get()
-                .medium()
-                .functions()
-                .get_media_track_info_value(self.get_raw(), Selected)
+            ReaperFunctions::get()                .get_media_track_info_value(self.get_raw(), Selected)
         };
         selected == 1.0
     }
@@ -496,50 +419,35 @@ impl Track {
     pub fn select(&self) {
         self.load_and_check_if_necessary_or_complain();
         unsafe {
-            Reaper::get()
-                .medium()
-                .functions()
-                .set_track_selected(self.get_raw(), true);
+            ReaperFunctions::get()                .set_track_selected(self.get_raw(), true);
         }
     }
 
     pub fn select_exclusively(&self) {
         self.load_and_check_if_necessary_or_complain();
         unsafe {
-            Reaper::get()
-                .medium()
-                .functions()
-                .set_only_track_selected(Some(self.get_raw()));
+            ReaperFunctions::get()                .set_only_track_selected(Some(self.get_raw()));
         }
     }
 
     pub fn unselect(&self) {
         self.load_and_check_if_necessary_or_complain();
         unsafe {
-            Reaper::get()
-                .medium()
-                .functions()
-                .set_track_selected(self.get_raw(), false);
+            ReaperFunctions::get()                .set_track_selected(self.get_raw(), false);
         }
     }
 
     pub fn get_send_count(&self) -> u32 {
         self.load_and_check_if_necessary_or_complain();
         unsafe {
-            Reaper::get()
-                .medium()
-                .functions()
-                .get_track_num_sends(self.get_raw(), TrackSendCategory::Send)
+            ReaperFunctions::get()                .get_track_num_sends(self.get_raw(), TrackSendCategory::Send)
         }
     }
 
     pub fn add_send_to(&self, target_track: Track) -> TrackSend {
         // TODO-low Check how this behaves if send already exists
         let send_index = unsafe {
-            Reaper::get()
-                .medium()
-                .functions()
-                .create_track_send(self.get_raw(), OtherTrack(target_track.get_raw()))
+            ReaperFunctions::get()                .create_track_send(self.get_raw(), OtherTrack(target_track.get_raw()))
         }
         .unwrap();
         TrackSend::target_based(self.clone(), target_track, Some(send_index))
@@ -618,10 +526,7 @@ impl Track {
             None => false,
             Some(rea_project) => {
                 if Project::new(rea_project).is_available() {
-                    Reaper::get()
-                        .medium()
-                        .functions()
-                        .validate_ptr_2(Proj(rea_project), media_track)
+                    ReaperFunctions::get()                        .validate_ptr_2(Proj(rea_project), media_track)
                 } else {
                     false
                 }
@@ -711,17 +616,14 @@ impl Track {
     pub fn get_automation_mode(&self) -> AutomationMode {
         self.load_and_check_if_necessary_or_complain();
         unsafe {
-            Reaper::get()
-                .medium()
-                .functions()
-                .get_track_automation_mode(self.media_track.get().unwrap())
+            ReaperFunctions::get()                .get_track_automation_mode(self.media_track.get().unwrap())
         }
     }
 
     // None means Bypass
     pub fn get_effective_automation_mode(&self) -> Option<AutomationMode> {
         use GlobalAutomationModeOverride::*;
-        match Reaper::get().get_global_automation_override() {
+        match ReaperFunctions::get().get_global_automation_override() {
             None => Some(self.get_automation_mode()),
             Some(Bypass) => None,
             Some(Mode(am)) => Some(am),
@@ -739,10 +641,7 @@ impl Track {
     pub fn is_master_track(&self) -> bool {
         self.load_and_check_if_necessary_or_complain();
         let t = unsafe {
-            Reaper::get()
-                .medium()
-                .functions()
-                .get_set_media_track_info_get_track_number(self.get_raw())
+            ReaperFunctions::get()                .get_set_media_track_info_get_track_number(self.get_raw())
         };
         t == Some(TrackRef::MasterTrack)
     }
@@ -768,10 +667,7 @@ impl PartialEq for Track {
 
 pub fn get_media_track_guid(media_track: MediaTrack) -> Guid {
     let internal = unsafe {
-        Reaper::get()
-            .medium()
-            .functions()
-            .get_set_media_track_info_get_guid(media_track)
+        ReaperFunctions::get()            .get_set_media_track_info_get_guid(media_track)
     };
     Guid::new(internal)
 }
@@ -780,10 +676,7 @@ pub fn get_media_track_guid(media_track: MediaTrack) -> Guid {
 // logic at a later point.
 fn get_track_project_raw(media_track: MediaTrack) -> Option<ReaProject> {
     unsafe {
-        Reaper::get()
-            .medium()
-            .functions()
-            .get_set_media_track_info_get_project(media_track)
+        ReaperFunctions::get()            .get_set_media_track_info_get_project(media_track)
     }
 }
 

--- a/main/high/src/track_send.rs
+++ b/main/high/src/track_send.rs
@@ -1,4 +1,4 @@
-use crate::{Pan, Reaper, Track, Volume};
+use crate::{Pan, Track, Volume};
 
 use reaper_medium::ValueChange::Absolute;
 use reaper_medium::{MediaTrack, ReaperFunctions, TrackSendDirection};

--- a/main/high/src/track_send.rs
+++ b/main/high/src/track_send.rs
@@ -1,7 +1,7 @@
 use crate::{Pan, Reaper, Track, Volume};
 
 use reaper_medium::ValueChange::Absolute;
-use reaper_medium::{MediaTrack, TrackSendDirection};
+use reaper_medium::{MediaTrack, ReaperFunctions, TrackSendDirection};
 use rxrust::prelude::PayloadCopy;
 use std::cell::Cell;
 
@@ -82,9 +82,7 @@ impl TrackSend {
         // It's important that we don't use GetTrackSendInfo_Value with D_VOL because it returns the
         // wrong value if an envelope is written.
         let result = unsafe {
-            Reaper::get()
-                .medium()
-                .functions()
+            ReaperFunctions::get()
                 .get_track_send_ui_vol_pan(self.get_source_track().get_raw(), self.get_index())
         }
         .expect("Couldn't get send vol/pan");
@@ -93,22 +91,17 @@ impl TrackSend {
 
     pub fn set_volume(&self, volume: Volume) {
         unsafe {
-            Reaper::get()
-                .medium()
-                .functions()
-                .csurf_on_send_volume_change(
-                    self.get_source_track().get_raw(),
-                    self.get_index(),
-                    Absolute(volume.get_reaper_value()),
-                );
+            ReaperFunctions::get().csurf_on_send_volume_change(
+                self.get_source_track().get_raw(),
+                self.get_index(),
+                Absolute(volume.get_reaper_value()),
+            );
         }
     }
 
     pub fn get_pan(&self) -> Pan {
         let result = unsafe {
-            Reaper::get()
-                .medium()
-                .functions()
+            ReaperFunctions::get()
                 .get_track_send_ui_vol_pan(self.get_source_track().get_raw(), self.get_index())
         }
         .expect("Couldn't get send vol/pan");
@@ -117,7 +110,7 @@ impl TrackSend {
 
     pub fn set_pan(&self, pan: Pan) {
         unsafe {
-            Reaper::get().medium().functions().csurf_on_send_pan_change(
+            ReaperFunctions::get().csurf_on_send_pan_change(
                 self.get_source_track().get_raw(),
                 self.get_index(),
                 Absolute(pan.get_reaper_value()),
@@ -203,14 +196,11 @@ pub(super) fn get_target_track(source_track: &Track, send_index: u32) -> Track {
 
 fn get_target_track_raw(source_track: &Track, send_index: u32) -> Option<MediaTrack> {
     unsafe {
-        Reaper::get()
-            .medium()
-            .functions()
-            .get_track_send_info_desttrack(
-                source_track.get_raw(),
-                TrackSendDirection::Send,
-                send_index,
-            )
+        ReaperFunctions::get().get_track_send_info_desttrack(
+            source_track.get_raw(),
+            TrackSendDirection::Send,
+            send_index,
+        )
     }
     .ok()
 }

--- a/main/high/src/volume.rs
+++ b/main/high/src/volume.rs
@@ -1,5 +1,5 @@
 use crate::Reaper;
-use reaper_medium::{Db, ReaperVolumeValue, VolumeSliderValue};
+use reaper_medium::{Db, ReaperFunctions, ReaperVolumeValue, VolumeSliderValue};
 
 pub struct Volume {
     normalized_value: f64,
@@ -21,9 +21,7 @@ impl Volume {
     }
 
     pub fn from_db(db: Db) -> Volume {
-        Volume::from_normalized_value(
-            Reaper::get().medium().functions().db2slider(db).get() / 1000.0,
-        )
+        Volume::from_normalized_value(ReaperFunctions::get().db2slider(db).get() / 1000.0)
     }
 
     pub fn get_normalized_value(&self) -> f64 {
@@ -35,9 +33,6 @@ impl Volume {
     }
 
     pub fn get_db(&self) -> Db {
-        Reaper::get()
-            .medium()
-            .functions()
-            .slider2db(VolumeSliderValue::new(self.normalized_value * 1000.0))
+        ReaperFunctions::get().slider2db(VolumeSliderValue::new(self.normalized_value * 1000.0))
     }
 }

--- a/main/high/src/volume.rs
+++ b/main/high/src/volume.rs
@@ -1,4 +1,4 @@
-use crate::Reaper;
+
 use reaper_medium::{Db, ReaperFunctions, ReaperVolumeValue, VolumeSliderValue};
 
 pub struct Volume {

--- a/main/high/src/volume.rs
+++ b/main/high/src/volume.rs
@@ -1,4 +1,3 @@
-
 use reaper_medium::{Db, ReaperFunctions, ReaperVolumeValue, VolumeSliderValue};
 
 pub struct Volume {

--- a/main/low/src/reaper_plugin_context.rs
+++ b/main/low/src/reaper_plugin_context.rs
@@ -22,6 +22,7 @@ pub struct ReaperPluginContext {
     type_specific: TypeSpecificReaperPluginContext,
     h_instance: raw::HINSTANCE,
     get_swell_func_ptr: Option<GetSwellFuncFn>,
+    main_thread_id: std::thread::ThreadId,
 }
 
 /// Additional stuff available in the plug-in context specific to a certain plug-in type.
@@ -93,6 +94,7 @@ impl ReaperPluginContext {
             ),
             h_instance,
             get_swell_func_ptr: static_context.get_swell_func,
+            main_thread_id: std::thread::current().id(),
         })
     }
 
@@ -118,6 +120,7 @@ impl ReaperPluginContext {
             }),
             h_instance: static_context.h_instance,
             get_swell_func_ptr: static_context.get_swell_func,
+            main_thread_id: std::thread::current().id(),
         })
     }
 
@@ -166,6 +169,11 @@ impl ReaperPluginContext {
     /// Returns the type-specific plug-in context.
     pub fn type_specific(&self) -> &TypeSpecificReaperPluginContext {
         &self.type_specific
+    }
+
+    /// Returns whether we are currently in the main thread.
+    pub fn is_in_main_thread(&self) -> bool {
+        std::thread::current().id() == self.main_thread_id
     }
 }
 

--- a/main/macros/src/lib.rs
+++ b/main/macros/src/lib.rs
@@ -66,6 +66,13 @@ pub fn reaper_extension_plugin(attr: TokenStream, input: TokenStream) -> TokenSt
     }
 }
 
+/// No-op macro as work-around for https://github.com/magnet/metered-rs/issues/23.
+#[doc(hidden)]
+#[proc_macro_attribute]
+pub fn measure(_: TokenStream, input: TokenStream) -> TokenStream {
+    input
+}
+
 fn generate_low_level_plugin_code(main_function: syn::ItemFn) -> TokenStream {
     let main_function_name = &main_function.sig.ident;
     let tokens = quote! {

--- a/main/medium/Cargo.toml
+++ b/main/medium/Cargo.toml
@@ -10,14 +10,24 @@ keywords = ["reaper", "daw", "plug-in", "audio", "midi"]
 edition = "2018"
 categories = ["api-bindings", "multimedia", "multimedia::audio"]
 
+[features]
+# Activates metering of functions which can be safely executed in the main thread only.
+reaper-measure-main = ["reaper-measure"]
+
+# Activates metering of functions which can be safely executed in the real-time audio thread.
+reaper-measure-audio = ["reaper-measure"]
+
+# For internal use only. In itself doesn't activate any measuring. Just provides the necessary data structures.
+reaper-measure = ["metered", "serde"]
+
 [dependencies]
 c_str_macro = "1.0.2"
 derive_more = "0.99.5"
 reaper-low = { version = "0.1.0", path = '../low' }
 helgoboss-midi = { version = "0.1.0" }
 enumflags2 = { version = "^0.6", features = ["not_literal"] }
-metered = "0.3.0"
-serde = { version = "1.0" }
+metered = { version = "0.3.0", optional = true }
+serde = { version = "1.0", optional = true }
 
 [dev-dependencies]
 version-sync = "0.9"

--- a/main/medium/Cargo.toml
+++ b/main/medium/Cargo.toml
@@ -22,7 +22,7 @@ reaper-macros = { path = "../macros" }
 helgoboss-midi = { version = "0.1.0" }
 enumflags2 = { version = "^0.6", features = ["not_literal"] }
 metered = { version = "0.3.0", optional = true }
-serde = { version = "1.0", optional = true}
+serde = { version = "1.0", optional = true }
 
 [dev-dependencies]
 version-sync = "0.9"

--- a/main/medium/Cargo.toml
+++ b/main/medium/Cargo.toml
@@ -16,6 +16,8 @@ derive_more = "0.99.5"
 reaper-low = { version = "0.1.0", path = '../low' }
 helgoboss-midi = { version = "0.1.0" }
 enumflags2 = { version = "^0.6", features = ["not_literal"] }
+metered = "0.3.0"
+serde = { version = "1.0" }
 
 [dev-dependencies]
 version-sync = "0.9"

--- a/main/medium/Cargo.toml
+++ b/main/medium/Cargo.toml
@@ -11,23 +11,18 @@ edition = "2018"
 categories = ["api-bindings", "multimedia", "multimedia::audio"]
 
 [features]
-# Activates metering of functions which can be safely executed in the main thread only.
-reaper-measure-main = ["reaper-measure"]
-
-# Activates metering of functions which can be safely executed in the real-time audio thread.
-reaper-measure-audio = ["reaper-measure"]
-
-# For internal use only. In itself doesn't activate any measuring. Just provides the necessary data structures.
-reaper-measure = ["metered", "serde"]
+# Activates measuring of function execution times.
+reaper-meter = ["metered", "serde"]
 
 [dependencies]
 c_str_macro = "1.0.2"
 derive_more = "0.99.5"
-reaper-low = { version = "0.1.0", path = '../low' }
+reaper-low = { version = "0.1.0", path = "../low" }
+reaper-macros = { path = "../macros" }
 helgoboss-midi = { version = "0.1.0" }
 enumflags2 = { version = "^0.6", features = ["not_literal"] }
 metered = { version = "0.3.0", optional = true }
-serde = { version = "1.0", optional = true }
+serde = { version = "1.0", optional = true}
 
 [dev-dependencies]
 version-sync = "0.9"

--- a/main/medium/src/lib.rs
+++ b/main/medium/src/lib.rs
@@ -346,6 +346,9 @@ pub use reaper_functions::*;
 mod util;
 use util::*;
 
+#[cfg(feature = "reaper-meter")]
+mod metering;
+
 mod string_types;
 pub use string_types::*;
 

--- a/main/medium/src/metering/mod.rs
+++ b/main/medium/src/metering/mod.rs
@@ -1,0 +1,5 @@
+mod nano_response_time;
+pub use nano_response_time::*;
+
+mod single_threaded_hdr_histogram;
+pub use single_threaded_hdr_histogram::*;

--- a/main/medium/src/metering/nano_response_time.rs
+++ b/main/medium/src/metering/nano_response_time.rs
@@ -1,0 +1,59 @@
+use crate::metering::SingleThreadedHdrHistogram;
+use metered::clear::Clear;
+use metered::metric::{Advice, Histogram, Metric, OnResult};
+use metered::Enter;
+use serde::{Serialize, Serializer};
+use std::fmt;
+use std::fmt::Debug;
+
+/// Like the original metered-rs ResponseTime metric but on nano-second granularity and not
+/// thread-safe.
+pub struct NanoResponseTime(SingleThreadedHdrHistogram);
+
+impl Default for NanoResponseTime {
+    fn default() -> Self {
+        // A HdrHistogram measuring latencies from 1ms to 5minutes
+        // All recordings will be saturating, that is, a value higher than 60 seconds
+        // will be replace by 60 seconds...
+        NanoResponseTime(SingleThreadedHdrHistogram::with_bound(60 * 1000_000_000))
+    }
+}
+
+impl<R> Metric<R> for NanoResponseTime {}
+
+impl Enter for NanoResponseTime {
+    type E = std::time::Instant;
+
+    fn enter(&self) -> std::time::Instant {
+        std::time::Instant::now()
+    }
+}
+
+impl<R> OnResult<R> for NanoResponseTime {
+    fn on_result(&self, enter: std::time::Instant, _: &R) -> Advice {
+        let elapsed = enter.elapsed();
+        self.0.record(elapsed.as_nanos() as u64);
+        Advice::Return
+    }
+}
+
+impl Clear for NanoResponseTime {
+    fn clear(&self) {
+        self.0.clear();
+    }
+}
+
+impl Serialize for NanoResponseTime {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        Serialize::serialize(&self.0, serializer)
+    }
+}
+
+impl Debug for NanoResponseTime {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", &self.0)
+    }
+}

--- a/main/medium/src/metering/nano_response_time.rs
+++ b/main/medium/src/metering/nano_response_time.rs
@@ -15,7 +15,7 @@ impl Default for NanoResponseTime {
         // A HdrHistogram measuring latencies from 1ms to 5minutes
         // All recordings will be saturating, that is, a value higher than 60 seconds
         // will be replace by 60 seconds...
-        NanoResponseTime(SingleThreadedHdrHistogram::with_bound(60 * 1000_000_000))
+        NanoResponseTime(SingleThreadedHdrHistogram::with_bound(60 * 1_000_000_000))
     }
 }
 

--- a/main/medium/src/metering/single_threaded_hdr_histogram.rs
+++ b/main/medium/src/metering/single_threaded_hdr_histogram.rs
@@ -1,0 +1,41 @@
+use metered::clear::Clear;
+use metered::hdr_histogram::HdrHistogram;
+use metered::metric::Histogram;
+use serde::{Serialize, Serializer};
+use std::cell::RefCell;
+
+/// A single-threaded implementation of HdrHistogram
+#[derive(Debug)]
+pub struct SingleThreadedHdrHistogram {
+    inner: RefCell<HdrHistogram>,
+}
+
+impl Histogram for SingleThreadedHdrHistogram {
+    fn with_bound(max_bound: u64) -> Self {
+        let histo = HdrHistogram::with_bound(max_bound);
+        let inner = RefCell::new(histo);
+        SingleThreadedHdrHistogram { inner }
+    }
+
+    fn record(&self, value: u64) {
+        self.inner.borrow_mut().record(value);
+    }
+}
+
+impl Clear for SingleThreadedHdrHistogram {
+    fn clear(&self) {
+        self.inner.borrow_mut().clear();
+    }
+}
+
+impl Serialize for SingleThreadedHdrHistogram {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use std::ops::Deref;
+        let inner = self.inner.borrow_mut();
+        let inner = inner.deref();
+        Serialize::serialize(inner, serializer)
+    }
+}

--- a/main/medium/src/reaper_functions.rs
+++ b/main/medium/src/reaper_functions.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "reaper-measure")]
 use metered::{metered, ResponseTime};
 use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_void};
@@ -28,18 +29,22 @@ use std::marker::PhantomData;
 use std::mem::MaybeUninit;
 use std::path::PathBuf;
 
+/// Represents a privilege to execute functions which are safe to execute from any thread.
+pub trait AnyThread: private::Sealed {}
+
 /// Represents a privilege to execute functions which are only safe to execute from the main thread.
-pub trait MainThreadOnly: private::Sealed {}
+pub trait MainThreadOnly: AnyThread + private::Sealed {}
+
+/// Represents a privilege to execute functions which are only safe to execute from the real-time
+/// audio thread.
+pub trait AudioThreadOnly: AnyThread + private::Sealed {}
 
 /// A usage scope which unlocks all functions that are safe to execute from the main thread.
 #[derive(Copy, Clone, Debug, Default)]
 pub struct MainThreadScope(pub(crate) ());
 
 impl MainThreadOnly for MainThreadScope {}
-
-/// Represents a privilege to execute functions which are only safe to execute from the real-time
-/// audio thread.
-pub trait AudioThreadOnly: private::Sealed {}
+impl AnyThread for MainThreadScope {}
 
 /// A usage scope which unlocks all functions that are safe to execute from the real-time audio
 /// thread.
@@ -47,6 +52,7 @@ pub trait AudioThreadOnly: private::Sealed {}
 pub struct RealTimeAudioThreadScope(pub(crate) ());
 
 impl AudioThreadOnly for RealTimeAudioThreadScope {}
+impl AnyThread for RealTimeAudioThreadScope {}
 
 /// This is the main access point for most REAPER functions.
 ///
@@ -130,6 +136,7 @@ impl AudioThreadOnly for RealTimeAudioThreadScope {}
 pub struct ReaperFunctions<UsageScope = MainThreadScope> {
     low: reaper_low::Reaper,
     p: PhantomData<UsageScope>,
+    #[cfg(feature = "reaper-measure")]
     metrics: ReaperMetrics,
 }
 
@@ -138,6 +145,7 @@ impl<UsageScope> Clone for ReaperFunctions<UsageScope> {
         Self {
             low: self.low.clone(),
             p: Default::default(),
+            #[cfg(feature = "reaper-measure")]
             metrics: Default::default(),
         }
     }
@@ -175,19 +183,18 @@ impl ReaperFunctions<MainThreadScope> {
     }
 }
 
-#[metered(registry = ReaperMetrics)]
-#[measure([ResponseTime])]
+#[cfg_attr(feature = "reaper-measure", metered(registry = ReaperMetrics), measure([ResponseTime]))]
 impl<UsageScope> ReaperFunctions<UsageScope> {
     pub(crate) fn new(low: reaper_low::Reaper) -> ReaperFunctions<UsageScope> {
         ReaperFunctions {
             low,
             p: PhantomData,
+            #[cfg(feature = "reaper-measure")]
             metrics: Default::default(),
         }
     }
 
     /// Gives access to the low-level Reaper instance.
-    #[measure]
     pub fn low(&self) -> &reaper_low::Reaper {
         &self.low
     }
@@ -218,7 +225,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     //  provide a feature to turn it on/off or make it a debug_assert only or provide an additional
     //  unchecked version. In audio-thread functions it might be too much overhead though calling
     //  is_in_real_time_audio() each time, so maybe we should mark them as unsafe.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub fn enum_projects(
         &self,
         project_ref: ProjectRef,
@@ -272,7 +279,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// let track = reaper.functions().get_track(CurrentProject, 3).ok_or("No such track")?;
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub fn get_track(&self, project: ProjectContext, track_index: u32) -> Option<MediaTrack>
     where
         UsageScope: MainThreadOnly,
@@ -288,7 +295,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid project.
     ///
     /// [`get_track()`]: #method.get_track
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn get_track_unchecked(
         &self,
         project: ProjectContext,
@@ -317,12 +324,15 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     ///
     /// Returns `true` if the pointer is a valid object of the correct type in the given project.
     /// The project is ignored if the pointer itself is a project.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-audio", measure)]
     pub fn validate_ptr_2<'a>(
         &self,
         project: ProjectContext,
         pointer: impl Into<ReaperPointer<'a>>,
-    ) -> bool {
+    ) -> bool
+    where
+        UsageScope: AnyThread,
+    {
         let pointer = pointer.into();
         unsafe {
             self.low.ValidatePtr2(
@@ -336,7 +346,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// Checks if the given pointer is still valid.
     ///
     /// Returns `true` if the pointer is a valid object of the correct type in the current project.
-    #[measure]
+    #[cfg_attr(feature = "measure", measure)]
     pub fn validate_ptr<'a>(&self, pointer: impl Into<ReaperPointer<'a>>) -> bool
     where
         UsageScope: MainThreadOnly,
@@ -349,7 +359,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     }
 
     /// Redraws the arrange view and ruler.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub fn update_timeline(&self)
     where
         UsageScope: MainThreadOnly,
@@ -360,8 +370,11 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// Shows a message to the user in the ReaScript console.
     ///
     /// This is also useful for debugging. Send "\n" for newline and "" to clear the console.
-    #[measure]
-    pub fn show_console_msg<'a>(&self, message: impl Into<ReaperStringArg<'a>>) {
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    pub fn show_console_msg<'a>(&self, message: impl Into<ReaperStringArg<'a>>)
+    where
+        UsageScope: MainThreadOnly,
+    {
         unsafe { self.low.ShowConsoleMsg(message.into().as_ptr()) }
     }
 
@@ -375,7 +388,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track or invalid new value.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn get_set_media_track_info(
         &self,
         track: MediaTrack,
@@ -394,7 +407,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn get_set_media_track_info_get_par_track(
         &self,
         track: MediaTrack,
@@ -414,7 +427,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn get_set_media_track_info_get_project(
         &self,
         track: MediaTrack,
@@ -456,7 +469,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn get_set_media_track_info_get_name<R>(
         &self,
         track: MediaTrack,
@@ -474,7 +487,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn get_set_media_track_info_get_rec_mon(
         &self,
         track: MediaTrack,
@@ -492,7 +505,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn get_set_media_track_info_get_rec_input(
         &self,
         track: MediaTrack,
@@ -515,7 +528,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn get_set_media_track_info_get_track_number(
         &self,
         track: MediaTrack,
@@ -539,7 +552,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn get_set_media_track_info_get_guid(&self, track: MediaTrack) -> GUID
     where
         UsageScope: MainThreadOnly,
@@ -554,8 +567,11 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// anticipative FX thread.
     ///
     /// [`OnAudioBuffer`]: trait.MediumOnAudioBuffer.html#method.call
-    #[measure]
-    pub fn is_in_real_time_audio(&self) -> bool {
+    #[cfg_attr(feature = "reaper-measure-audio", measure)]
+    pub fn is_in_real_time_audio(&self) -> bool
+    where
+        UsageScope: AnyThread,
+    {
         self.low.IsInRealTimeAudio() != 0
     }
 
@@ -569,8 +585,11 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// Panics if the given project is not valid anymore.
     ///
     /// [`named_command_lookup()`]: #method.named_command_lookup
-    #[measure]
-    pub fn main_on_command_ex(&self, command: CommandId, flag: i32, project: ProjectContext) {
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    pub fn main_on_command_ex(&self, command: CommandId, flag: i32, project: ProjectContext)
+    where
+        UsageScope: MainThreadOnly,
+    {
         self.require_valid_project(project);
         unsafe { self.main_on_command_ex_unchecked(command, flag, project) }
     }
@@ -582,13 +601,15 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid project.
     ///
     /// [`main_on_command_ex()`]: #method.main_on_command_ex
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn main_on_command_ex_unchecked(
         &self,
         command_id: CommandId,
         flag: i32,
         project: ProjectContext,
-    ) {
+    ) where
+        UsageScope: MainThreadOnly,
+    {
         self.low
             .Main_OnCommandEx(command_id.to_raw(), flag, project.to_raw());
     }
@@ -611,13 +632,15 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// }
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn csurf_set_surface_mute(
         &self,
         track: MediaTrack,
         mute: bool,
         notification_behavior: NotificationBehavior,
-    ) {
+    ) where
+        UsageScope: MainThreadOnly,
+    {
         self.low
             .CSurf_SetSurfaceMute(track.as_ptr(), mute, notification_behavior.to_raw());
     }
@@ -627,19 +650,21 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn csurf_set_surface_solo(
         &self,
         track: MediaTrack,
         solo: bool,
         notification_behavior: NotificationBehavior,
-    ) {
+    ) where
+        UsageScope: MainThreadOnly,
+    {
         self.low
             .CSurf_SetSurfaceSolo(track.as_ptr(), solo, notification_behavior.to_raw());
     }
 
     /// Generates a random GUID.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub fn gen_guid(&self) -> GUID
     where
         UsageScope: MainThreadOnly,
@@ -666,7 +691,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     //
     // In order to not need unsafe, we take the closure. For normal medium-level API usage, this is
     // the safe way to go.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub fn section_from_unique_id<R>(
         &self,
         section_id: SectionId,
@@ -694,7 +719,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     // that a section is always valid, e.g. if it's the main section. A higher-level API could
     // use this for such edge cases. If not the main section, a higher-level API
     // should check if the section still exists (via section index) before each usage.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn section_from_unique_id_unchecked(
         &self,
         section_id: SectionId,
@@ -717,7 +742,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     ///
     /// [`main_on_command_ex()`]: #method.main_on_command_ex
     // Kept return value type i32 because I have no idea what the return value is about.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn kbd_on_main_action_ex(
         &self,
         command_id: CommandId,
@@ -751,7 +776,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     }
 
     /// Returns the REAPER main window handle.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub fn get_main_hwnd(&self) -> Hwnd
     where
         UsageScope: MainThreadOnly,
@@ -763,7 +788,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     ///
     /// Named commands can be registered by extensions (e.g. `_SWS_ABOUT`), ReaScripts
     /// (e.g. `_113088d11ae641c193a2b7ede3041ad5`) or custom actions.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub fn named_command_lookup<'a>(
         &self,
         command_name: impl Into<ReaperStringArg<'a>>,
@@ -779,8 +804,11 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     }
 
     /// Clears the ReaScript console.
-    #[measure]
-    pub fn clear_console(&self) {
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    pub fn clear_console(&self)
+    where
+        UsageScope: MainThreadOnly,
+    {
         self.low.ClearConsole();
     }
 
@@ -789,7 +817,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Panics
     ///
     /// Panics if the given project is not valid anymore.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub fn count_tracks(&self, project: ProjectContext) -> u32
     where
         UsageScope: MainThreadOnly,
@@ -805,7 +833,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid project.
     ///
     /// [`count_tracks()`]: #method.count_tracks
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn count_tracks_unchecked(&self, project: ProjectContext) -> u32
     where
         UsageScope: MainThreadOnly,
@@ -814,8 +842,11 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     }
 
     /// Creates a new track at the given index.
-    #[measure]
-    pub fn insert_track_at_index(&self, index: u32, defaults_behavior: TrackDefaultsBehavior) {
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    pub fn insert_track_at_index(&self, index: u32, defaults_behavior: TrackDefaultsBehavior)
+    where
+        UsageScope: MainThreadOnly,
+    {
         self.low.InsertTrackAtIndex(
             index as i32,
             defaults_behavior == TrackDefaultsBehavior::AddDefaultEnvAndFx,
@@ -823,14 +854,20 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     }
 
     /// Returns the maximum number of MIDI input devices (usually 63).
-    #[measure]
-    pub fn get_max_midi_inputs(&self) -> u32 {
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    pub fn get_max_midi_inputs(&self) -> u32
+    where
+        UsageScope: AnyThread,
+    {
         self.low.GetMaxMidiInputs() as u32
     }
 
     /// Returns the maximum number of MIDI output devices (usually 64).
-    #[measure]
-    pub fn get_max_midi_outputs(&self) -> u32 {
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    pub fn get_max_midi_outputs(&self) -> u32
+    where
+        UsageScope: AnyThread,
+    {
         self.low.GetMaxMidiOutputs() as u32
     }
 
@@ -838,7 +875,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     ///
     /// With `buffer_size` you can tell REAPER how many bytes of the device name you want.
     /// If you are not interested in the device name at all, pass 0.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub fn get_midi_input_name(
         &self,
         device_id: MidiInputDeviceId,
@@ -876,7 +913,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     ///
     /// With `buffer_size` you can tell REAPER how many bytes of the device name you want.
     /// If you are not interested in the device name at all, pass 0.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub fn get_midi_output_name(
         &self,
         device_id: MidiOutputDeviceId,
@@ -941,7 +978,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn track_fx_add_by_name_query<'a>(
         &self,
         track: MediaTrack,
@@ -971,7 +1008,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid track.
     ///
     /// [`track_fx_add_by_name_query()`]: #method.track_fx_add_by_name_query
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn track_fx_add_by_name_add<'a>(
         &self,
         track: MediaTrack,
@@ -994,7 +1031,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn track_fx_get_enabled(
         &self,
         track: MediaTrack,
@@ -1022,7 +1059,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn track_fx_get_fx_name(
         &self,
         track: MediaTrack,
@@ -1052,7 +1089,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn track_fx_get_instrument(&self, track: MediaTrack) -> Option<u32>
     where
         UsageScope: MainThreadOnly,
@@ -1069,13 +1106,15 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn track_fx_set_enabled(
         &self,
         track: MediaTrack,
         fx_location: TrackFxLocation,
         is_enabled: bool,
-    ) {
+    ) where
+        UsageScope: MainThreadOnly,
+    {
         self.low
             .TrackFX_SetEnabled(track.as_ptr(), fx_location.to_raw(), is_enabled);
     }
@@ -1085,7 +1124,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn track_fx_get_num_params(
         &self,
         track: MediaTrack,
@@ -1102,7 +1141,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     ///
     /// This is usually only used from `project_config_extension_t`.
     // TODO-low `project_config_extension_t` is not yet ported
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub fn get_current_project_in_load_save(&self) -> Option<ReaProject>
     where
         UsageScope: MainThreadOnly,
@@ -1126,7 +1165,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn track_fx_get_param_name(
         &self,
         track: MediaTrack,
@@ -1171,7 +1210,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn track_fx_get_formatted_param_value(
         &self,
         track: MediaTrack,
@@ -1223,7 +1262,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid track.
     ///
     /// [`track_fx_get_formatted_param_value`]: #method.track_fx_get_formatted_param_value
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn track_fx_format_param_value_normalized(
         &self,
         track: MediaTrack,
@@ -1263,7 +1302,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn track_fx_set_param_normalized(
         &self,
         track: MediaTrack,
@@ -1292,7 +1331,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     ///
     /// Returns `Some` if an FX window has focus or was the last focused one and is still open.
     /// Returns `None` if no FX window has focus.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub fn get_focused_fx(&self) -> Option<GetFocusedFxResult>
     where
         UsageScope: MainThreadOnly,
@@ -1338,7 +1377,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     ///
     /// Returns `Some` if an FX parameter has been touched already and that FX is still existing.
     /// Returns `None` otherwise.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub fn get_last_touched_fx(&self) -> Option<GetLastTouchedFxResult>
     where
         UsageScope: MainThreadOnly,
@@ -1391,13 +1430,15 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn track_fx_copy_to_track(
         &self,
         source: (MediaTrack, TrackFxLocation),
         destination: (MediaTrack, TrackFxLocation),
         transfer_behavior: TransferBehavior,
-    ) {
+    ) where
+        UsageScope: MainThreadOnly,
+    {
         self.low.TrackFX_CopyToTrack(
             source.0.as_ptr(),
             source.1.to_raw(),
@@ -1416,7 +1457,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn track_fx_delete(
         &self,
         track: MediaTrack,
@@ -1448,7 +1489,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     // Option makes more sense than Result here because this function is at the same time the
     // correct function to be used to determine *if* a parameter reports step sizes. So
     // "parameter doesn't report step sizes" is a valid result.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn track_fx_get_parameter_step_sizes(
         &self,
         track: MediaTrack,
@@ -1491,7 +1532,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn track_fx_get_param_ex(
         &self,
         track: MediaTrack,
@@ -1536,8 +1577,11 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// // ... modify something ...
     /// reaper.functions().undo_end_block_2(CurrentProject, "Modify something", Scoped(Items | Fx));
     /// ```
-    #[measure]
-    pub fn undo_begin_block_2(&self, project: ProjectContext) {
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    pub fn undo_begin_block_2(&self, project: ProjectContext)
+    where
+        UsageScope: MainThreadOnly,
+    {
         self.require_valid_project(project);
         unsafe { self.undo_begin_block_2_unchecked(project) };
     }
@@ -1549,8 +1593,11 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid project.
     ///
     /// [`undo_begin_block_2()`]: #method.undo_begin_block_2
-    #[measure]
-    pub unsafe fn undo_begin_block_2_unchecked(&self, project: ProjectContext) {
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    pub unsafe fn undo_begin_block_2_unchecked(&self, project: ProjectContext)
+    where
+        UsageScope: MainThreadOnly,
+    {
         self.low.Undo_BeginBlock2(project.to_raw());
     }
 
@@ -1559,13 +1606,15 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Panics
     ///
     /// Panics if the given project is not valid anymore.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub fn undo_end_block_2<'a>(
         &self,
         project: ProjectContext,
         description: impl Into<ReaperStringArg<'a>>,
         scope: UndoScope,
-    ) {
+    ) where
+        UsageScope: MainThreadOnly,
+    {
         self.require_valid_project(project);
         unsafe {
             self.undo_end_block_2_unchecked(project, description, scope);
@@ -1579,13 +1628,15 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid project.
     ///
     /// [`undo_end_block_2()`]: #method.undo_end_block_2
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn undo_end_block_2_unchecked<'a>(
         &self,
         project: ProjectContext,
         description: impl Into<ReaperStringArg<'a>>,
         scope: UndoScope,
-    ) {
+    ) where
+        UsageScope: MainThreadOnly,
+    {
         self.low.Undo_EndBlock2(
             project.to_raw(),
             description.into().as_ptr(),
@@ -1598,7 +1649,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Panics
     ///
     /// Panics if the given project is not valid anymore.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub fn undo_can_undo_2<R>(
         &self,
         project: ProjectContext,
@@ -1618,7 +1669,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid project.
     ///
     /// [`undo_can_undo_2()`]: #method.undo_can_undo_2
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn undo_can_undo_2_unchecked<R>(
         &self,
         project: ProjectContext,
@@ -1636,7 +1687,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Panics
     ///
     /// Panics if the given project is not valid anymore.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub fn undo_can_redo_2<R>(
         &self,
         project: ProjectContext,
@@ -1656,7 +1707,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid project.
     ///
     /// [`undo_can_redo_2()`]: #method.undo_can_redo_2
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn undo_can_redo_2_unchecked<R>(
         &self,
         project: ProjectContext,
@@ -1676,7 +1727,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Panics
     ///
     /// Panics if the given project is not valid anymore.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub fn undo_do_undo_2(&self, project: ProjectContext) -> bool
     where
         UsageScope: MainThreadOnly,
@@ -1692,7 +1743,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid project.
     ///
     /// [`undo_do_undo_2()`]: #method.undo_do_undo_2
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn undo_do_undo_2_unchecked(&self, project: ProjectContext) -> bool
     where
         UsageScope: MainThreadOnly,
@@ -1707,7 +1758,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Panics
     ///
     /// Panics if the given project is not valid anymore.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub fn undo_do_redo_2(&self, project: ProjectContext) -> bool
     where
         UsageScope: MainThreadOnly,
@@ -1723,7 +1774,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid project.
     ///
     /// [`undo_do_redo_2()`]: #method.undo_do_redo_2
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn undo_do_redo_2_unchecked(&self, project: ProjectContext) -> bool
     where
         UsageScope: MainThreadOnly,
@@ -1739,8 +1790,11 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Panics
     ///
     /// Panics if the given project is not valid anymore.
-    #[measure]
-    pub fn mark_project_dirty(&self, project: ProjectContext) {
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    pub fn mark_project_dirty(&self, project: ProjectContext)
+    where
+        UsageScope: MainThreadOnly,
+    {
         self.require_valid_project(project);
         unsafe {
             self.mark_project_dirty_unchecked(project);
@@ -1754,8 +1808,11 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid project.
     ///
     /// [`mark_project_dirty()`]: #method.mark_project_dirty
-    #[measure]
-    pub unsafe fn mark_project_dirty_unchecked(&self, project: ProjectContext) {
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    pub unsafe fn mark_project_dirty_unchecked(&self, project: ProjectContext)
+    where
+        UsageScope: MainThreadOnly,
+    {
         self.low.MarkProjectDirty(project.to_raw());
     }
 
@@ -1770,7 +1827,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// Panics if the given project is not valid anymore.
     ///
     /// [`mark_project_dirty()`]: #method.mark_project_dirty
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub fn is_project_dirty(&self, project: ProjectContext) -> bool
     where
         UsageScope: MainThreadOnly,
@@ -1786,7 +1843,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid project.
     ///
     /// [`is_project_dirty()`]: #method.is_project_dirty
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn is_project_dirty_unchecked(&self, project: ProjectContext) -> bool
     where
         UsageScope: MainThreadOnly,
@@ -1797,13 +1854,16 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// Notifies all control surfaces that something in the track list has changed.
     ///
     /// Behavior not confirmed.
-    #[measure]
-    pub fn track_list_update_all_external_surfaces(&self) {
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    pub fn track_list_update_all_external_surfaces(&self)
+    where
+        UsageScope: MainThreadOnly,
+    {
         self.low.TrackList_UpdateAllExternalSurfaces();
     }
 
     /// Returns the version of the REAPER application in which this plug-in is currently running.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub fn get_app_version(&self) -> ReaperVersion<'static>
     where
         UsageScope: MainThreadOnly,
@@ -1818,7 +1878,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn get_track_automation_mode(&self, track: MediaTrack) -> AutomationMode
     where
         UsageScope: MainThreadOnly,
@@ -1828,7 +1888,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     }
 
     /// Returns the global track automation override, if any.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub fn get_global_automation_override(&self) -> Option<GlobalAutomationModeOverride>
     where
         UsageScope: MainThreadOnly,
@@ -1849,7 +1909,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     ///
     /// REAPER can crash if you pass an invalid track.
     // TODO-low Test
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn get_track_envelope_by_chunk_name(
         &self,
         track: MediaTrack,
@@ -1874,7 +1934,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid track.
     ///
     /// [`get_track_envelope_by_chunk_name()`]: #method.get_track_envelope_by_chunk_name
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn get_track_envelope_by_name<'a>(
         &self,
         track: MediaTrack,
@@ -1894,7 +1954,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn get_media_track_info_value(
         &self,
         track: MediaTrack,
@@ -1912,7 +1972,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn track_fx_get_count(&self, track: MediaTrack) -> u32
     where
         UsageScope: MainThreadOnly,
@@ -1927,7 +1987,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn track_fx_get_rec_count(&self, track: MediaTrack) -> u32
     where
         UsageScope: MainThreadOnly,
@@ -1944,7 +2004,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn track_fx_get_fx_guid(
         &self,
         track: MediaTrack,
@@ -1970,7 +2030,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn track_fx_get_param_normalized(
         &self,
         track: MediaTrack,
@@ -1998,7 +2058,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Panics
     ///
     /// Panics if the given project is not valid anymore.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub fn get_master_track(&self, project: ProjectContext) -> MediaTrack
     where
         UsageScope: MainThreadOnly,
@@ -2014,7 +2074,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid project.
     ///
     /// [`get_master_track()`]: #method.get_master_track
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn get_master_track_unchecked(&self, project: ProjectContext) -> MediaTrack
     where
         UsageScope: MainThreadOnly,
@@ -2024,7 +2084,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     }
 
     /// Converts the given GUID to a string (including braces).
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub fn guid_to_string(&self, guid: &GUID) -> CString
     where
         UsageScope: MainThreadOnly,
@@ -2036,7 +2096,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     }
 
     /// Returns the master tempo of the current project.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub fn master_get_tempo(&self) -> Bpm
     where
         UsageScope: MainThreadOnly,
@@ -2049,13 +2109,11 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Panics
     ///
     /// Panics if the given project is not valid anymore.
-    #[measure]
-    pub fn set_current_bpm(
-        &self,
-        project: ProjectContext,
-        tempo: Bpm,
-        undo_behavior: UndoBehavior,
-    ) {
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    pub fn set_current_bpm(&self, project: ProjectContext, tempo: Bpm, undo_behavior: UndoBehavior)
+    where
+        UsageScope: MainThreadOnly,
+    {
         self.require_valid_project(project);
         unsafe {
             self.set_current_bpm_unchecked(project, tempo, undo_behavior);
@@ -2069,13 +2127,15 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid project.
     ///
     /// [`set_current_bpm()`]: #method.set_current_bpm
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn set_current_bpm_unchecked(
         &self,
         project: ProjectContext,
         tempo: Bpm,
         undo_behavior: UndoBehavior,
-    ) {
+    ) where
+        UsageScope: MainThreadOnly,
+    {
         self.low.SetCurrentBPM(
             project.to_raw(),
             tempo.get(),
@@ -2088,7 +2148,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Panics
     ///
     /// Panics if the given project is not valid anymore.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub fn master_get_play_rate(&self, project: ProjectContext) -> PlaybackSpeedFactor
     where
         UsageScope: MainThreadOnly,
@@ -2104,7 +2164,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid project.
     ///
     /// [`master_get_play_rate()`]: #method.master_get_play_rate
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn master_get_play_rate_unchecked(
         &self,
         project: ProjectContext,
@@ -2117,7 +2177,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     }
 
     /// Sets the master play rate of the current project.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub fn csurf_on_play_rate_change(&self, play_rate: PlaybackSpeedFactor) {
         self.low.CSurf_OnPlayRateChange(play_rate.get());
     }
@@ -2125,7 +2185,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// Shows a message box to the user.
     ///
     /// Blocks the main thread.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub fn show_message_box<'a>(
         &self,
         message: impl Into<ReaperStringArg<'a>>,
@@ -2150,7 +2210,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Errors
     ///
     /// Returns an error if the given string is not a valid GUID string.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub fn string_to_guid<'a>(
         &self,
         guid_string: impl Into<ReaperStringArg<'a>>,
@@ -2175,7 +2235,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn csurf_on_input_monitoring_change_ex(
         &self,
         track: MediaTrack,
@@ -2201,7 +2261,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn set_media_track_info_value(
         &self,
         track: MediaTrack,
@@ -2225,8 +2285,11 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     }
 
     /// Stuffs a 3-byte MIDI message into a queue or send it to an external MIDI hardware.
-    #[measure]
-    pub fn stuff_midimessage(&self, target: StuffMidiMessageTarget, message: impl ShortMessage) {
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    pub fn stuff_midimessage(&self, target: StuffMidiMessageTarget, message: impl ShortMessage)
+    where
+        UsageScope: MainThreadOnly,
+    {
         let bytes = message.to_bytes();
         self.low.StuffMIDIMessage(
             target.to_raw(),
@@ -2237,7 +2300,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     }
 
     /// Converts a decibel value into a volume slider value.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub fn db2slider(&self, value: Db) -> VolumeSliderValue
     where
         UsageScope: MainThreadOnly,
@@ -2246,7 +2309,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     }
 
     /// Converts a volume slider value into a decibel value.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub fn slider2db(&self, value: VolumeSliderValue) -> Db
     where
         UsageScope: MainThreadOnly,
@@ -2263,7 +2326,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn get_track_ui_vol_pan(
         &self,
         track: MediaTrack,
@@ -2292,13 +2355,15 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn csurf_set_surface_volume(
         &self,
         track: MediaTrack,
         volume: ReaperVolumeValue,
         notification_behavior: NotificationBehavior,
-    ) {
+    ) where
+        UsageScope: MainThreadOnly,
+    {
         self.low.CSurf_SetSurfaceVolume(
             track.as_ptr(),
             volume.get(),
@@ -2314,7 +2379,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn csurf_on_volume_change_ex(
         &self,
         track: MediaTrack,
@@ -2338,13 +2403,15 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn csurf_set_surface_pan(
         &self,
         track: MediaTrack,
         pan: ReaperPanValue,
         notification_behavior: NotificationBehavior,
-    ) {
+    ) where
+        UsageScope: MainThreadOnly,
+    {
         self.low
             .CSurf_SetSurfacePan(track.as_ptr(), pan.get(), notification_behavior.to_raw());
     }
@@ -2356,7 +2423,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn csurf_on_pan_change_ex(
         &self,
         track: MediaTrack,
@@ -2380,7 +2447,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Panics
     ///
     /// Panics if the given project is not valid anymore.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub fn count_selected_tracks_2(
         &self,
         project: ProjectContext,
@@ -2400,7 +2467,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid project.
     ///
     /// [`count_selected_tracks_2()`]: #method.count_selected_tracks_2
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn count_selected_tracks_2_unchecked(
         &self,
         project: ProjectContext,
@@ -2420,8 +2487,11 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
-    pub unsafe fn set_track_selected(&self, track: MediaTrack, is_selected: bool) {
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    pub unsafe fn set_track_selected(&self, track: MediaTrack, is_selected: bool)
+    where
+        UsageScope: MainThreadOnly,
+    {
         self.low.SetTrackSelected(track.as_ptr(), is_selected);
     }
 
@@ -2430,7 +2500,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Panics
     ///
     /// Panics if the given project is not valid anymore.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub fn get_selected_track_2(
         &self,
         project: ProjectContext,
@@ -2457,7 +2527,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid project.
     ///
     /// [`get_selected_track_2()`]: #method.get_selected_track_2
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn get_selected_track_2_unchecked(
         &self,
         project: ProjectContext,
@@ -2482,8 +2552,11 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
-    pub unsafe fn set_only_track_selected(&self, track: Option<MediaTrack>) {
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    pub unsafe fn set_only_track_selected(&self, track: Option<MediaTrack>)
+    where
+        UsageScope: MainThreadOnly,
+    {
         let ptr = match track {
             None => null_mut(),
             Some(t) => t.as_ptr(),
@@ -2496,8 +2569,11 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
-    pub unsafe fn delete_track(&self, track: MediaTrack) {
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    pub unsafe fn delete_track(&self, track: MediaTrack)
+    where
+        UsageScope: MainThreadOnly,
+    {
         self.low.DeleteTrack(track.as_ptr());
     }
 
@@ -2506,7 +2582,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn get_track_num_sends(&self, track: MediaTrack, category: TrackSendCategory) -> u32
     where
         UsageScope: MainThreadOnly,
@@ -2521,7 +2597,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track or invalid new value.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn get_set_track_send_info(
         &self,
         track: MediaTrack,
@@ -2552,7 +2628,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn get_track_send_info_desttrack(
         &self,
         track: MediaTrack,
@@ -2589,7 +2665,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn get_track_state_chunk(
         &self,
         track: MediaTrack,
@@ -2638,7 +2714,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// };
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn create_track_send(
         &self,
         track: MediaTrack,
@@ -2661,7 +2737,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn csurf_on_rec_arm_change_ex(
         &self,
         track: MediaTrack,
@@ -2687,7 +2763,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn set_track_state_chunk<'a>(
         &self,
         track: MediaTrack,
@@ -2715,8 +2791,11 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
-    pub unsafe fn track_fx_show(&self, track: MediaTrack, instruction: FxShowInstruction) {
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    pub unsafe fn track_fx_show(&self, track: MediaTrack, instruction: FxShowInstruction)
+    where
+        UsageScope: MainThreadOnly,
+    {
         self.low.TrackFX_Show(
             track.as_ptr(),
             instruction.location_to_raw(),
@@ -2729,7 +2808,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn track_fx_get_floating_window(
         &self,
         track: MediaTrack,
@@ -2751,7 +2830,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn track_fx_get_open(&self, track: MediaTrack, fx_location: TrackFxLocation) -> bool
     where
         UsageScope: MainThreadOnly,
@@ -2768,7 +2847,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn csurf_on_send_volume_change(
         &self,
         track: MediaTrack,
@@ -2794,7 +2873,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn csurf_on_send_pan_change(
         &self,
         track: MediaTrack,
@@ -2821,7 +2900,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid section.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn kbd_get_text_from_cmd<R>(
         &self,
         command_id: CommandId,
@@ -2851,7 +2930,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     // Option makes more sense than Result here because this function is at the same time the
     // correct function to be used to determine *if* an action reports on/off states. So
     // "action doesn't report on/off states" is a valid result.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn get_toggle_command_state_2(
         &self,
         section: SectionContext,
@@ -2874,7 +2953,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// The string will *not* start with `_` (e.g. it will return `SWS_ABOUT`).
     ///
     /// Returns `None` if the given command ID is a built-in action or if there's no such ID.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub fn reverse_named_command_lookup<R>(
         &self,
         command_id: CommandId,
@@ -2898,7 +2977,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid track.
     // // send_idx>=0 for hw ouputs, >=nb_of_hw_ouputs for sends. See GetTrackReceiveUIVolPan.
     // Returns Err if send not existing
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn get_track_send_ui_vol_pan(
         &self,
         track: MediaTrack,
@@ -2935,7 +3014,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn track_fx_get_preset_index(
         &self,
         track: MediaTrack,
@@ -2970,7 +3049,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn track_fx_set_preset_by_index(
         &self,
         track: MediaTrack,
@@ -3017,7 +3096,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// };
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn track_fx_navigate_presets(
         &self,
         track: MediaTrack,
@@ -3048,7 +3127,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-main", measure)]
     pub unsafe fn track_fx_get_preset(
         &self,
         track: MediaTrack,
@@ -3114,7 +3193,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// [audio hook]: struct.Reaper.html#method.audio_reg_hardware_hook_add
     /// [`is_in_real_time_audio()`]: #method.is_in_real_time_audio
     /// [`get_read_buf()`]: struct.MidiInput.html#method.get_read_buf
-    #[measure]
+    #[cfg_attr(feature = "reaper-measure-audio", measure)]
     pub fn get_midi_input<R>(
         &self,
         device_id: MidiInputDeviceId,
@@ -3130,7 +3209,10 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
         NonNull::new(ptr).map(|nnp| use_device(&MidiInput(nnp)))
     }
 
-    fn require_valid_project(&self, project: ProjectContext) {
+    fn require_valid_project(&self, project: ProjectContext)
+    where
+        UsageScope: AnyThread,
+    {
         if let ProjectContext::Proj(p) = project {
             assert!(
                 self.validate_ptr_2(CurrentProject, p),

--- a/main/medium/src/reaper_functions.rs
+++ b/main/medium/src/reaper_functions.rs
@@ -152,7 +152,7 @@ pub struct ReaperFunctions<UsageScope = MainThreadScope> {
 impl<UsageScope> Clone for ReaperFunctions<UsageScope> {
     fn clone(&self) -> Self {
         Self {
-            low: *self.low,
+            low: self.low,
             p: Default::default(),
             #[cfg(feature = "reaper-meter")]
             metrics: Default::default(),

--- a/main/medium/src/reaper_functions.rs
+++ b/main/medium/src/reaper_functions.rs
@@ -152,7 +152,7 @@ pub struct ReaperFunctions<UsageScope = MainThreadScope> {
 impl<UsageScope> Clone for ReaperFunctions<UsageScope> {
     fn clone(&self) -> Self {
         Self {
-            low: self.low.clone(),
+            low: *self.low,
             p: Default::default(),
             #[cfg(feature = "reaper-meter")]
             metrics: Default::default(),

--- a/main/medium/src/reaper_functions.rs
+++ b/main/medium/src/reaper_functions.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "reaper-meter")]
-use metered::{metered, ResponseTime};
+use crate::metering::NanoResponseTime;
+#[cfg(feature = "reaper-meter")]
+use metered::metered;
 #[cfg(not(feature = "reaper-meter"))]
 use reaper_macros::measure;
 use std::ffi::{CStr, CString};
@@ -185,7 +187,7 @@ impl ReaperFunctions<MainThreadScope> {
     }
 }
 
-#[cfg_attr(feature = "reaper-meter", metered(registry = ReaperMetrics), measure([ResponseTime]))]
+#[cfg_attr(feature = "reaper-meter", metered(registry = ReaperMetrics), measure([NanoResponseTime]))]
 impl<UsageScope> ReaperFunctions<UsageScope> {
     pub(crate) fn new(low: reaper_low::Reaper) -> ReaperFunctions<UsageScope> {
         ReaperFunctions {

--- a/main/medium/src/reaper_functions.rs
+++ b/main/medium/src/reaper_functions.rs
@@ -1,5 +1,7 @@
-#[cfg(feature = "reaper-measure")]
+#[cfg(feature = "reaper-meter")]
 use metered::{metered, ResponseTime};
+#[cfg(not(feature = "reaper-meter"))]
+use reaper_macros::measure;
 use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_void};
 use std::ptr::{null_mut, NonNull};
@@ -136,7 +138,7 @@ impl AnyThread for RealTimeAudioThreadScope {}
 pub struct ReaperFunctions<UsageScope = MainThreadScope> {
     low: reaper_low::Reaper,
     p: PhantomData<UsageScope>,
-    #[cfg(feature = "reaper-measure")]
+    #[cfg(feature = "reaper-meter")]
     metrics: ReaperMetrics,
 }
 
@@ -145,7 +147,7 @@ impl<UsageScope> Clone for ReaperFunctions<UsageScope> {
         Self {
             low: self.low.clone(),
             p: Default::default(),
-            #[cfg(feature = "reaper-measure")]
+            #[cfg(feature = "reaper-meter")]
             metrics: Default::default(),
         }
     }
@@ -183,13 +185,13 @@ impl ReaperFunctions<MainThreadScope> {
     }
 }
 
-#[cfg_attr(feature = "reaper-measure", metered(registry = ReaperMetrics), measure([ResponseTime]))]
+#[cfg_attr(feature = "reaper-meter", metered(registry = ReaperMetrics), measure([ResponseTime]))]
 impl<UsageScope> ReaperFunctions<UsageScope> {
     pub(crate) fn new(low: reaper_low::Reaper) -> ReaperFunctions<UsageScope> {
         ReaperFunctions {
             low,
             p: PhantomData,
-            #[cfg(feature = "reaper-measure")]
+            #[cfg(feature = "reaper-meter")]
             metrics: Default::default(),
         }
     }
@@ -225,7 +227,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     //  provide a feature to turn it on/off or make it a debug_assert only or provide an additional
     //  unchecked version. In audio-thread functions it might be too much overhead though calling
     //  is_in_real_time_audio() each time, so maybe we should mark them as unsafe.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn enum_projects(
         &self,
         project_ref: ProjectRef,
@@ -279,7 +281,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// let track = reaper.functions().get_track(CurrentProject, 3).ok_or("No such track")?;
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn get_track(&self, project: ProjectContext, track_index: u32) -> Option<MediaTrack>
     where
         UsageScope: MainThreadOnly,
@@ -295,7 +297,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid project.
     ///
     /// [`get_track()`]: #method.get_track
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn get_track_unchecked(
         &self,
         project: ProjectContext,
@@ -324,7 +326,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     ///
     /// Returns `true` if the pointer is a valid object of the correct type in the given project.
     /// The project is ignored if the pointer itself is a project.
-    #[cfg_attr(feature = "reaper-measure-audio", measure)]
+    #[measure]
     pub fn validate_ptr_2<'a>(
         &self,
         project: ProjectContext,
@@ -359,7 +361,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     }
 
     /// Redraws the arrange view and ruler.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn update_timeline(&self)
     where
         UsageScope: MainThreadOnly,
@@ -370,7 +372,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// Shows a message to the user in the ReaScript console.
     ///
     /// This is also useful for debugging. Send "\n" for newline and "" to clear the console.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn show_console_msg<'a>(&self, message: impl Into<ReaperStringArg<'a>>)
     where
         UsageScope: MainThreadOnly,
@@ -388,7 +390,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track or invalid new value.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn get_set_media_track_info(
         &self,
         track: MediaTrack,
@@ -407,7 +409,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn get_set_media_track_info_get_par_track(
         &self,
         track: MediaTrack,
@@ -427,7 +429,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn get_set_media_track_info_get_project(
         &self,
         track: MediaTrack,
@@ -469,7 +471,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn get_set_media_track_info_get_name<R>(
         &self,
         track: MediaTrack,
@@ -487,7 +489,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn get_set_media_track_info_get_rec_mon(
         &self,
         track: MediaTrack,
@@ -505,7 +507,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn get_set_media_track_info_get_rec_input(
         &self,
         track: MediaTrack,
@@ -528,7 +530,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn get_set_media_track_info_get_track_number(
         &self,
         track: MediaTrack,
@@ -552,7 +554,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn get_set_media_track_info_get_guid(&self, track: MediaTrack) -> GUID
     where
         UsageScope: MainThreadOnly,
@@ -567,7 +569,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// anticipative FX thread.
     ///
     /// [`OnAudioBuffer`]: trait.MediumOnAudioBuffer.html#method.call
-    #[cfg_attr(feature = "reaper-measure-audio", measure)]
+    #[measure]
     pub fn is_in_real_time_audio(&self) -> bool
     where
         UsageScope: AnyThread,
@@ -585,7 +587,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// Panics if the given project is not valid anymore.
     ///
     /// [`named_command_lookup()`]: #method.named_command_lookup
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn main_on_command_ex(&self, command: CommandId, flag: i32, project: ProjectContext)
     where
         UsageScope: MainThreadOnly,
@@ -601,7 +603,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid project.
     ///
     /// [`main_on_command_ex()`]: #method.main_on_command_ex
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn main_on_command_ex_unchecked(
         &self,
         command_id: CommandId,
@@ -632,7 +634,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// }
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn csurf_set_surface_mute(
         &self,
         track: MediaTrack,
@@ -650,7 +652,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn csurf_set_surface_solo(
         &self,
         track: MediaTrack,
@@ -664,7 +666,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     }
 
     /// Generates a random GUID.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn gen_guid(&self) -> GUID
     where
         UsageScope: MainThreadOnly,
@@ -691,7 +693,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     //
     // In order to not need unsafe, we take the closure. For normal medium-level API usage, this is
     // the safe way to go.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn section_from_unique_id<R>(
         &self,
         section_id: SectionId,
@@ -719,7 +721,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     // that a section is always valid, e.g. if it's the main section. A higher-level API could
     // use this for such edge cases. If not the main section, a higher-level API
     // should check if the section still exists (via section index) before each usage.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn section_from_unique_id_unchecked(
         &self,
         section_id: SectionId,
@@ -742,7 +744,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     ///
     /// [`main_on_command_ex()`]: #method.main_on_command_ex
     // Kept return value type i32 because I have no idea what the return value is about.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn kbd_on_main_action_ex(
         &self,
         command_id: CommandId,
@@ -776,7 +778,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     }
 
     /// Returns the REAPER main window handle.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn get_main_hwnd(&self) -> Hwnd
     where
         UsageScope: MainThreadOnly,
@@ -788,7 +790,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     ///
     /// Named commands can be registered by extensions (e.g. `_SWS_ABOUT`), ReaScripts
     /// (e.g. `_113088d11ae641c193a2b7ede3041ad5`) or custom actions.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn named_command_lookup<'a>(
         &self,
         command_name: impl Into<ReaperStringArg<'a>>,
@@ -804,7 +806,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     }
 
     /// Clears the ReaScript console.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn clear_console(&self)
     where
         UsageScope: MainThreadOnly,
@@ -817,7 +819,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Panics
     ///
     /// Panics if the given project is not valid anymore.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn count_tracks(&self, project: ProjectContext) -> u32
     where
         UsageScope: MainThreadOnly,
@@ -833,7 +835,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid project.
     ///
     /// [`count_tracks()`]: #method.count_tracks
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn count_tracks_unchecked(&self, project: ProjectContext) -> u32
     where
         UsageScope: MainThreadOnly,
@@ -842,7 +844,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     }
 
     /// Creates a new track at the given index.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn insert_track_at_index(&self, index: u32, defaults_behavior: TrackDefaultsBehavior)
     where
         UsageScope: MainThreadOnly,
@@ -854,7 +856,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     }
 
     /// Returns the maximum number of MIDI input devices (usually 63).
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn get_max_midi_inputs(&self) -> u32
     where
         UsageScope: AnyThread,
@@ -863,7 +865,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     }
 
     /// Returns the maximum number of MIDI output devices (usually 64).
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn get_max_midi_outputs(&self) -> u32
     where
         UsageScope: AnyThread,
@@ -875,7 +877,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     ///
     /// With `buffer_size` you can tell REAPER how many bytes of the device name you want.
     /// If you are not interested in the device name at all, pass 0.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn get_midi_input_name(
         &self,
         device_id: MidiInputDeviceId,
@@ -913,7 +915,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     ///
     /// With `buffer_size` you can tell REAPER how many bytes of the device name you want.
     /// If you are not interested in the device name at all, pass 0.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn get_midi_output_name(
         &self,
         device_id: MidiOutputDeviceId,
@@ -978,7 +980,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn track_fx_add_by_name_query<'a>(
         &self,
         track: MediaTrack,
@@ -1008,7 +1010,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid track.
     ///
     /// [`track_fx_add_by_name_query()`]: #method.track_fx_add_by_name_query
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn track_fx_add_by_name_add<'a>(
         &self,
         track: MediaTrack,
@@ -1031,7 +1033,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn track_fx_get_enabled(
         &self,
         track: MediaTrack,
@@ -1059,7 +1061,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn track_fx_get_fx_name(
         &self,
         track: MediaTrack,
@@ -1089,7 +1091,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn track_fx_get_instrument(&self, track: MediaTrack) -> Option<u32>
     where
         UsageScope: MainThreadOnly,
@@ -1106,7 +1108,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn track_fx_set_enabled(
         &self,
         track: MediaTrack,
@@ -1124,7 +1126,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn track_fx_get_num_params(
         &self,
         track: MediaTrack,
@@ -1141,7 +1143,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     ///
     /// This is usually only used from `project_config_extension_t`.
     // TODO-low `project_config_extension_t` is not yet ported
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn get_current_project_in_load_save(&self) -> Option<ReaProject>
     where
         UsageScope: MainThreadOnly,
@@ -1165,7 +1167,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn track_fx_get_param_name(
         &self,
         track: MediaTrack,
@@ -1210,7 +1212,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn track_fx_get_formatted_param_value(
         &self,
         track: MediaTrack,
@@ -1262,7 +1264,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid track.
     ///
     /// [`track_fx_get_formatted_param_value`]: #method.track_fx_get_formatted_param_value
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn track_fx_format_param_value_normalized(
         &self,
         track: MediaTrack,
@@ -1302,7 +1304,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn track_fx_set_param_normalized(
         &self,
         track: MediaTrack,
@@ -1331,7 +1333,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     ///
     /// Returns `Some` if an FX window has focus or was the last focused one and is still open.
     /// Returns `None` if no FX window has focus.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn get_focused_fx(&self) -> Option<GetFocusedFxResult>
     where
         UsageScope: MainThreadOnly,
@@ -1377,7 +1379,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     ///
     /// Returns `Some` if an FX parameter has been touched already and that FX is still existing.
     /// Returns `None` otherwise.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn get_last_touched_fx(&self) -> Option<GetLastTouchedFxResult>
     where
         UsageScope: MainThreadOnly,
@@ -1430,7 +1432,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn track_fx_copy_to_track(
         &self,
         source: (MediaTrack, TrackFxLocation),
@@ -1457,7 +1459,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn track_fx_delete(
         &self,
         track: MediaTrack,
@@ -1489,7 +1491,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     // Option makes more sense than Result here because this function is at the same time the
     // correct function to be used to determine *if* a parameter reports step sizes. So
     // "parameter doesn't report step sizes" is a valid result.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn track_fx_get_parameter_step_sizes(
         &self,
         track: MediaTrack,
@@ -1532,7 +1534,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn track_fx_get_param_ex(
         &self,
         track: MediaTrack,
@@ -1577,7 +1579,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// // ... modify something ...
     /// reaper.functions().undo_end_block_2(CurrentProject, "Modify something", Scoped(Items | Fx));
     /// ```
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn undo_begin_block_2(&self, project: ProjectContext)
     where
         UsageScope: MainThreadOnly,
@@ -1593,7 +1595,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid project.
     ///
     /// [`undo_begin_block_2()`]: #method.undo_begin_block_2
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn undo_begin_block_2_unchecked(&self, project: ProjectContext)
     where
         UsageScope: MainThreadOnly,
@@ -1606,7 +1608,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Panics
     ///
     /// Panics if the given project is not valid anymore.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn undo_end_block_2<'a>(
         &self,
         project: ProjectContext,
@@ -1628,7 +1630,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid project.
     ///
     /// [`undo_end_block_2()`]: #method.undo_end_block_2
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn undo_end_block_2_unchecked<'a>(
         &self,
         project: ProjectContext,
@@ -1649,7 +1651,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Panics
     ///
     /// Panics if the given project is not valid anymore.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn undo_can_undo_2<R>(
         &self,
         project: ProjectContext,
@@ -1669,7 +1671,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid project.
     ///
     /// [`undo_can_undo_2()`]: #method.undo_can_undo_2
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn undo_can_undo_2_unchecked<R>(
         &self,
         project: ProjectContext,
@@ -1687,7 +1689,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Panics
     ///
     /// Panics if the given project is not valid anymore.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn undo_can_redo_2<R>(
         &self,
         project: ProjectContext,
@@ -1707,7 +1709,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid project.
     ///
     /// [`undo_can_redo_2()`]: #method.undo_can_redo_2
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn undo_can_redo_2_unchecked<R>(
         &self,
         project: ProjectContext,
@@ -1727,7 +1729,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Panics
     ///
     /// Panics if the given project is not valid anymore.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn undo_do_undo_2(&self, project: ProjectContext) -> bool
     where
         UsageScope: MainThreadOnly,
@@ -1743,7 +1745,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid project.
     ///
     /// [`undo_do_undo_2()`]: #method.undo_do_undo_2
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn undo_do_undo_2_unchecked(&self, project: ProjectContext) -> bool
     where
         UsageScope: MainThreadOnly,
@@ -1758,7 +1760,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Panics
     ///
     /// Panics if the given project is not valid anymore.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn undo_do_redo_2(&self, project: ProjectContext) -> bool
     where
         UsageScope: MainThreadOnly,
@@ -1774,7 +1776,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid project.
     ///
     /// [`undo_do_redo_2()`]: #method.undo_do_redo_2
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn undo_do_redo_2_unchecked(&self, project: ProjectContext) -> bool
     where
         UsageScope: MainThreadOnly,
@@ -1790,7 +1792,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Panics
     ///
     /// Panics if the given project is not valid anymore.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn mark_project_dirty(&self, project: ProjectContext)
     where
         UsageScope: MainThreadOnly,
@@ -1808,7 +1810,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid project.
     ///
     /// [`mark_project_dirty()`]: #method.mark_project_dirty
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn mark_project_dirty_unchecked(&self, project: ProjectContext)
     where
         UsageScope: MainThreadOnly,
@@ -1827,7 +1829,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// Panics if the given project is not valid anymore.
     ///
     /// [`mark_project_dirty()`]: #method.mark_project_dirty
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn is_project_dirty(&self, project: ProjectContext) -> bool
     where
         UsageScope: MainThreadOnly,
@@ -1843,7 +1845,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid project.
     ///
     /// [`is_project_dirty()`]: #method.is_project_dirty
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn is_project_dirty_unchecked(&self, project: ProjectContext) -> bool
     where
         UsageScope: MainThreadOnly,
@@ -1854,7 +1856,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// Notifies all control surfaces that something in the track list has changed.
     ///
     /// Behavior not confirmed.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn track_list_update_all_external_surfaces(&self)
     where
         UsageScope: MainThreadOnly,
@@ -1863,7 +1865,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     }
 
     /// Returns the version of the REAPER application in which this plug-in is currently running.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn get_app_version(&self) -> ReaperVersion<'static>
     where
         UsageScope: MainThreadOnly,
@@ -1878,7 +1880,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn get_track_automation_mode(&self, track: MediaTrack) -> AutomationMode
     where
         UsageScope: MainThreadOnly,
@@ -1888,7 +1890,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     }
 
     /// Returns the global track automation override, if any.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn get_global_automation_override(&self) -> Option<GlobalAutomationModeOverride>
     where
         UsageScope: MainThreadOnly,
@@ -1909,7 +1911,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     ///
     /// REAPER can crash if you pass an invalid track.
     // TODO-low Test
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn get_track_envelope_by_chunk_name(
         &self,
         track: MediaTrack,
@@ -1934,7 +1936,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid track.
     ///
     /// [`get_track_envelope_by_chunk_name()`]: #method.get_track_envelope_by_chunk_name
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn get_track_envelope_by_name<'a>(
         &self,
         track: MediaTrack,
@@ -1954,7 +1956,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn get_media_track_info_value(
         &self,
         track: MediaTrack,
@@ -1972,7 +1974,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn track_fx_get_count(&self, track: MediaTrack) -> u32
     where
         UsageScope: MainThreadOnly,
@@ -1987,7 +1989,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn track_fx_get_rec_count(&self, track: MediaTrack) -> u32
     where
         UsageScope: MainThreadOnly,
@@ -2004,7 +2006,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn track_fx_get_fx_guid(
         &self,
         track: MediaTrack,
@@ -2030,7 +2032,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn track_fx_get_param_normalized(
         &self,
         track: MediaTrack,
@@ -2058,7 +2060,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Panics
     ///
     /// Panics if the given project is not valid anymore.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn get_master_track(&self, project: ProjectContext) -> MediaTrack
     where
         UsageScope: MainThreadOnly,
@@ -2074,7 +2076,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid project.
     ///
     /// [`get_master_track()`]: #method.get_master_track
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn get_master_track_unchecked(&self, project: ProjectContext) -> MediaTrack
     where
         UsageScope: MainThreadOnly,
@@ -2084,7 +2086,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     }
 
     /// Converts the given GUID to a string (including braces).
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn guid_to_string(&self, guid: &GUID) -> CString
     where
         UsageScope: MainThreadOnly,
@@ -2096,7 +2098,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     }
 
     /// Returns the master tempo of the current project.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn master_get_tempo(&self) -> Bpm
     where
         UsageScope: MainThreadOnly,
@@ -2109,7 +2111,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Panics
     ///
     /// Panics if the given project is not valid anymore.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn set_current_bpm(&self, project: ProjectContext, tempo: Bpm, undo_behavior: UndoBehavior)
     where
         UsageScope: MainThreadOnly,
@@ -2127,7 +2129,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid project.
     ///
     /// [`set_current_bpm()`]: #method.set_current_bpm
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn set_current_bpm_unchecked(
         &self,
         project: ProjectContext,
@@ -2148,7 +2150,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Panics
     ///
     /// Panics if the given project is not valid anymore.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn master_get_play_rate(&self, project: ProjectContext) -> PlaybackSpeedFactor
     where
         UsageScope: MainThreadOnly,
@@ -2164,7 +2166,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid project.
     ///
     /// [`master_get_play_rate()`]: #method.master_get_play_rate
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn master_get_play_rate_unchecked(
         &self,
         project: ProjectContext,
@@ -2177,7 +2179,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     }
 
     /// Sets the master play rate of the current project.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn csurf_on_play_rate_change(&self, play_rate: PlaybackSpeedFactor) {
         self.low.CSurf_OnPlayRateChange(play_rate.get());
     }
@@ -2185,7 +2187,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// Shows a message box to the user.
     ///
     /// Blocks the main thread.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn show_message_box<'a>(
         &self,
         message: impl Into<ReaperStringArg<'a>>,
@@ -2210,7 +2212,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Errors
     ///
     /// Returns an error if the given string is not a valid GUID string.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn string_to_guid<'a>(
         &self,
         guid_string: impl Into<ReaperStringArg<'a>>,
@@ -2235,7 +2237,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn csurf_on_input_monitoring_change_ex(
         &self,
         track: MediaTrack,
@@ -2261,7 +2263,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn set_media_track_info_value(
         &self,
         track: MediaTrack,
@@ -2285,7 +2287,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     }
 
     /// Stuffs a 3-byte MIDI message into a queue or send it to an external MIDI hardware.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn stuff_midimessage(&self, target: StuffMidiMessageTarget, message: impl ShortMessage)
     where
         UsageScope: MainThreadOnly,
@@ -2300,7 +2302,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     }
 
     /// Converts a decibel value into a volume slider value.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn db2slider(&self, value: Db) -> VolumeSliderValue
     where
         UsageScope: MainThreadOnly,
@@ -2309,7 +2311,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     }
 
     /// Converts a volume slider value into a decibel value.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn slider2db(&self, value: VolumeSliderValue) -> Db
     where
         UsageScope: MainThreadOnly,
@@ -2326,7 +2328,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn get_track_ui_vol_pan(
         &self,
         track: MediaTrack,
@@ -2355,7 +2357,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn csurf_set_surface_volume(
         &self,
         track: MediaTrack,
@@ -2379,7 +2381,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn csurf_on_volume_change_ex(
         &self,
         track: MediaTrack,
@@ -2403,7 +2405,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn csurf_set_surface_pan(
         &self,
         track: MediaTrack,
@@ -2423,7 +2425,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn csurf_on_pan_change_ex(
         &self,
         track: MediaTrack,
@@ -2447,7 +2449,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Panics
     ///
     /// Panics if the given project is not valid anymore.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn count_selected_tracks_2(
         &self,
         project: ProjectContext,
@@ -2467,7 +2469,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid project.
     ///
     /// [`count_selected_tracks_2()`]: #method.count_selected_tracks_2
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn count_selected_tracks_2_unchecked(
         &self,
         project: ProjectContext,
@@ -2487,7 +2489,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn set_track_selected(&self, track: MediaTrack, is_selected: bool)
     where
         UsageScope: MainThreadOnly,
@@ -2500,7 +2502,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Panics
     ///
     /// Panics if the given project is not valid anymore.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn get_selected_track_2(
         &self,
         project: ProjectContext,
@@ -2527,7 +2529,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid project.
     ///
     /// [`get_selected_track_2()`]: #method.get_selected_track_2
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn get_selected_track_2_unchecked(
         &self,
         project: ProjectContext,
@@ -2552,7 +2554,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn set_only_track_selected(&self, track: Option<MediaTrack>)
     where
         UsageScope: MainThreadOnly,
@@ -2569,7 +2571,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn delete_track(&self, track: MediaTrack)
     where
         UsageScope: MainThreadOnly,
@@ -2582,7 +2584,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn get_track_num_sends(&self, track: MediaTrack, category: TrackSendCategory) -> u32
     where
         UsageScope: MainThreadOnly,
@@ -2597,7 +2599,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track or invalid new value.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn get_set_track_send_info(
         &self,
         track: MediaTrack,
@@ -2628,7 +2630,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn get_track_send_info_desttrack(
         &self,
         track: MediaTrack,
@@ -2665,7 +2667,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn get_track_state_chunk(
         &self,
         track: MediaTrack,
@@ -2714,7 +2716,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// };
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn create_track_send(
         &self,
         track: MediaTrack,
@@ -2737,7 +2739,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn csurf_on_rec_arm_change_ex(
         &self,
         track: MediaTrack,
@@ -2763,7 +2765,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn set_track_state_chunk<'a>(
         &self,
         track: MediaTrack,
@@ -2791,7 +2793,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn track_fx_show(&self, track: MediaTrack, instruction: FxShowInstruction)
     where
         UsageScope: MainThreadOnly,
@@ -2808,7 +2810,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn track_fx_get_floating_window(
         &self,
         track: MediaTrack,
@@ -2830,7 +2832,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn track_fx_get_open(&self, track: MediaTrack, fx_location: TrackFxLocation) -> bool
     where
         UsageScope: MainThreadOnly,
@@ -2847,7 +2849,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn csurf_on_send_volume_change(
         &self,
         track: MediaTrack,
@@ -2873,7 +2875,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn csurf_on_send_pan_change(
         &self,
         track: MediaTrack,
@@ -2900,7 +2902,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid section.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn kbd_get_text_from_cmd<R>(
         &self,
         command_id: CommandId,
@@ -2930,7 +2932,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     // Option makes more sense than Result here because this function is at the same time the
     // correct function to be used to determine *if* an action reports on/off states. So
     // "action doesn't report on/off states" is a valid result.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn get_toggle_command_state_2(
         &self,
         section: SectionContext,
@@ -2953,7 +2955,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// The string will *not* start with `_` (e.g. it will return `SWS_ABOUT`).
     ///
     /// Returns `None` if the given command ID is a built-in action or if there's no such ID.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub fn reverse_named_command_lookup<R>(
         &self,
         command_id: CommandId,
@@ -2977,7 +2979,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// REAPER can crash if you pass an invalid track.
     // // send_idx>=0 for hw ouputs, >=nb_of_hw_ouputs for sends. See GetTrackReceiveUIVolPan.
     // Returns Err if send not existing
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn get_track_send_ui_vol_pan(
         &self,
         track: MediaTrack,
@@ -3014,7 +3016,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn track_fx_get_preset_index(
         &self,
         track: MediaTrack,
@@ -3049,7 +3051,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn track_fx_set_preset_by_index(
         &self,
         track: MediaTrack,
@@ -3096,7 +3098,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// };
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn track_fx_navigate_presets(
         &self,
         track: MediaTrack,
@@ -3127,7 +3129,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// # Safety
     ///
     /// REAPER can crash if you pass an invalid track.
-    #[cfg_attr(feature = "reaper-measure-main", measure)]
+    #[measure]
     pub unsafe fn track_fx_get_preset(
         &self,
         track: MediaTrack,
@@ -3193,7 +3195,7 @@ impl<UsageScope> ReaperFunctions<UsageScope> {
     /// [audio hook]: struct.Reaper.html#method.audio_reg_hardware_hook_add
     /// [`is_in_real_time_audio()`]: #method.is_in_real_time_audio
     /// [`get_read_buf()`]: struct.MidiInput.html#method.get_read_buf
-    #[cfg_attr(feature = "reaper-measure-audio", measure)]
+    #[measure]
     pub fn get_midi_input<R>(
         &self,
         device_id: MidiInputDeviceId,

--- a/test/test-vst-plugin/src/lib.rs
+++ b/test/test-vst-plugin/src/lib.rs
@@ -105,7 +105,7 @@ impl TestVstPlugin {
             med.functions()
                 .show_console_msg("Registering control surface ...");
             med.plugin_register_add_csurf_inst(MyControlSurface {
-                functions: *med.functions(),
+                functions: med.functions().clone(),
                 receiver,
             })
             .expect("couldn't register control surface");

--- a/test/test/Cargo.toml
+++ b/test/test/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 reaper-high = { path = "../../main/high" }
-reaper-medium = { path = "../../main/medium" }
+reaper-medium = { path = "../../main/medium", features = ["reaper-measure-main", "reaper-measure-audio"] }
 reaper-low = { path = "../../main/low" }
 c_str_macro = "1.0.2"
 rxrust = "0.8.3"

--- a/test/test/Cargo.toml
+++ b/test/test/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 
 
 [dependencies]
-reaper-high = { path = "../../main/high" }
-reaper-medium = { path = "../../main/medium", features = ["reaper-measure-main", "reaper-measure-audio"] }
+reaper-high = { path = "../../main/high", features = ["reaper-meter"] }
+reaper-medium = { path = "../../main/medium", features = ["reaper-meter"] }
 reaper-low = { path = "../../main/low" }
 c_str_macro = "1.0.2"
 rxrust = "0.8.3"

--- a/test/test/src/tests.rs
+++ b/test/test/src/tests.rs
@@ -111,6 +111,7 @@ pub fn create_test_steps() -> impl Iterator<Item = TestStep> {
         get_project_tempo(),
         set_project_tempo(),
         swell(),
+        metrics(),
     ]
     .into_iter();
     let output_fx_steps = create_fx_steps("Output FX chain", || {
@@ -143,6 +144,16 @@ fn swell() -> TestStep {
         //     c_str!("reaper-rs SWELL").as_ptr(),
         //     1,
         // );
+    })
+}
+
+fn metrics() -> TestStep {
+    step(AllVersions, "Metrics", |reaper, _| {
+        println!(
+            "reaper_medium::Reaper metrics after integration test: {:#?}",
+            reaper.medium().functions()
+        );
+        Ok(())
     })
 }
 
@@ -1772,8 +1783,8 @@ fn global_instances() -> TestStep {
         Swell::make_available_globally(swell);
         let _ = Swell::get();
         // Medium-level REAPER
-        reaper_medium::ReaperFunctions::make_available_globally(*medium.functions());
-        reaper_medium::ReaperFunctions::make_available_globally(*medium.functions());
+        reaper_medium::ReaperFunctions::make_available_globally(medium.functions().clone());
+        reaper_medium::ReaperFunctions::make_available_globally(medium.functions().clone());
         let medium_functions = reaper_medium::ReaperFunctions::get();
         medium_functions.show_console_msg("- Hello from medium-level API\n");
         Ok(())


### PR DESCRIPTION
Resolves #4.

As a side note: The high-level panic hook's logging mechanism is not yet ready for panicking in another thread than the main thread. This is marked with a TODO.