### PR TITLE
Correct misinformation about plugin name requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,12 +232,12 @@ macro, have a look at the macro implementation. No magic there.
 
 The following instructions should result in a functional extension, loaded into REAPER on start:
 
-1. Run `cargo new reaper-my-extension --lib` to initialize the project
-2. Run `cargo build` from within `reaper-my-extension` to generate the compiled plugin extension inside of the `target/debug` directory
+1. Run `cargo new reaper_my_extension --lib` to initialize the project
+2. Run `cargo build` from within `reaper_my_extension` to generate the compiled plugin extension inside of the `target/debug` directory
 3. Copy the extension plug-in to the `REAPER/UserPlugins` directory
     - You could do this manually, and overwrite the file after each build
     - Or, you could create a symbolic link from the `target/debug` file, to `REAPER/UserPlugins` so that they were synced
-        - > Note: Here it's explicitly necessary to give the link a name that starts with` reaper` (by default it will start with `lib`)
+        - > Note: Here it's explicitly necessary to give the link a name that starts with `reaper_` (by default it will start with `lib`)
         - To do this, on unix-based systems, run `ln -s ./target/debug/<name-of-the-compiled-extension-file> <path to REAPER/UserPlugins>`
         - On Windows, you can use the same command if running Git Bash, else you can use `mklink \D target\debug\<name-of-the-compiled-extension-file> %AppData%\REAPER\UserPlugins`
 4. Now start REAPER, and you should see the console message from the code appear!

--- a/README.md
+++ b/README.md
@@ -232,8 +232,8 @@ macro, have a look at the macro implementation. No magic there.
 
 The following instructions should result in a functional extension, loaded into REAPER on start:
 
-1. Run `cargo new reaper_my_extension --lib` to initialize the project
-2. Run `cargo build` from within `reaper_my_extension` to generate the compiled plugin extension inside of the `target/debug` directory
+1. Run `cargo new reaper-my-extension --lib` to initialize the project
+2. Run `cargo build` from within `reaper-my-extension` to generate the compiled plugin extension inside of the `target/debug` directory
 3. Copy the extension plug-in to the `REAPER/UserPlugins` directory
     - You could do this manually, and overwrite the file after each build
     - Or, you could create a symbolic link from the `target/debug` file, to `REAPER/UserPlugins` so that they were synced


### PR DESCRIPTION
Plugin name needs to start with `reaper_` not just `reaper`, my mistake.
From REAPER source:

```c
    if ( strnicmp("reaper_", v9, 7ui64) )
      goto LABEL_78;

    if ( stricmp(&v9[v10 - 4], ".dll")
      || !strnicmp(v9, "_reaper_python", 0xEui64)
      || !strnicmp(v9, "reaper_perl", 0xBui64)
      || !strnicmp(v9, "reaper_php", 0xAui64) )
    {
      goto LABEL_78;
    }

LABEL_78:
    if ( hFindFile != (HANDLE)-1i64 )
    {
      if ( v40[0] )
      {
        if ( FindNextFileW(hFindFile, &FindFileData) )
          continue;
      }
      else if ( FindNextFileA(hFindFile, (LPWIN32_FIND_DATAA)&FindFileData) )
      {
        continue;
      }
    }
    break;
```