### PR TITLE
Provide helpers to get I/O buffers in OnAudioBuffer handlers

### DIFF
--- a/main/medium/src/audio_hook_register.rs
+++ b/main/medium/src/audio_hook_register.rs
@@ -124,7 +124,7 @@ impl OwnedAudioHookRegister {
                 userdata1: encode_user_data(&callback),
                 userdata2: null_mut(),
                 input_nch: 0,
-                output_nch: 0,
+                output_nch: 2,
                 GetBuffer: None,
             },
             callback,

--- a/main/medium/src/audio_hook_register.rs
+++ b/main/medium/src/audio_hook_register.rs
@@ -39,7 +39,7 @@ pub struct OnAudioBufferArgs<'a> {
 // We don't expose the user-defined data pointers. The first one is already exposed implicitly as
 // `&mut self` in the callback function. The second one is unnecessary.
 #[derive(Eq, PartialEq, Hash, Debug)]
-pub struct AudioHookRegister(pub(crate) NonNull<raw::audio_hook_register_t>);
+pub struct AudioHookRegister(pub NonNull<raw::audio_hook_register_t>);
 
 impl AudioHookRegister {
     pub(crate) fn new(ptr: NonNull<raw::audio_hook_register_t>) -> AudioHookRegister {

--- a/main/medium/src/audio_hook_register.rs
+++ b/main/medium/src/audio_hook_register.rs
@@ -58,7 +58,7 @@ impl AudioHookRegister {
 
     /// Returns the current number of output channels.
     pub fn output_nch(&self) -> u32 {
-        unsafe { self.0.as_ref() }.input_nch as u32
+        unsafe { self.0.as_ref() }.output_nch as u32
     }
 }
 


### PR DESCRIPTION
Added `output_channel_samples` and `input_channel_samples` to get to I/O buffers inside OnAudioBuffer handlers.