### PR TITLE
Midi functions draft

### DIFF
--- a/main/medium/src/lib.rs
+++ b/main/medium/src/lib.rs
@@ -371,6 +371,9 @@ pub use control_surface::*;
 mod midi;
 pub use midi::*;
 
+mod source_midi;
+pub use source_midi::*;
+
 mod pcm_source;
 pub use pcm_source::*;
 

--- a/main/medium/src/misc_enums.rs
+++ b/main/medium/src/misc_enums.rs
@@ -1589,7 +1589,7 @@ impl InsertMediaMode {
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default, Display)]
-pub enum CcShape {
+pub enum CcShapeKind {
     #[default]
     Square = 0,
     Linear = 16,

--- a/main/medium/src/misc_enums.rs
+++ b/main/medium/src/misc_enums.rs
@@ -1591,10 +1591,34 @@ impl InsertMediaMode {
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default, Display)]
 pub enum CcShapeKind {
     #[default]
-    Square = 0,
-    Linear = 16,
-    SlowStartEnd = 32,
-    FastStart = 16 | 32,
-    FastEnd = 64,
-    Beizer = 16 | 64,
+    Square,
+    Linear,
+    SlowStartEnd,
+    FastStart,
+    FastEnd,
+    Beizer,
+}
+impl CcShapeKind {
+    pub fn from_raw(value: u8) -> Self {
+        match value {
+            v if v == 0 => Self::Square,
+            v if v == 16 => Self::Linear,
+            v if v == 32 => Self::SlowStartEnd,
+            v if v == 16 | 32 => Self::FastStart,
+            v if v == 64 => Self::FastEnd,
+            v if v == 16 | 64 => Self::Beizer,
+            _ => panic!("not a cc shape: {:?}", value),
+        }
+    }
+
+    pub fn to_raw(&self) -> u8 {
+        match self {
+            Self::Square => 0,
+            Self::Linear => 16,
+            Self::SlowStartEnd => 32,
+            Self::FastStart => 16 | 32,
+            Self::FastEnd => 64,
+            Self::Beizer => 16 | 64,
+        }
+    }
 }

--- a/main/medium/src/misc_enums.rs
+++ b/main/medium/src/misc_enums.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 
 use crate::util::concat_reaper_strs;
+use derive_more::Display;
 use enumflags2::BitFlags;
 use helgoboss_midi::{U14, U7};
 use reaper_low::raw;
@@ -1585,4 +1586,15 @@ impl InsertMediaMode {
         };
         bits as i32
     }
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default, Display)]
+pub enum CcShape {
+    #[default]
+    Square = 0,
+    Linear = 16,
+    SlowStartEnd = 32,
+    FastStart = 16 | 32,
+    FastEnd = 64,
+    Beizer = 16 | 64,
 }

--- a/main/medium/src/misc_newtypes.rs
+++ b/main/medium/src/misc_newtypes.rs
@@ -1,5 +1,5 @@
 //! This module defines various newtypes in order to achieve more type safety.
-use crate::{ReaperStr, ReaperStringArg, TryFromGreaterError};
+use crate::{CcShape, ReaperStr, ReaperStringArg, TryFromGreaterError};
 use derive_more::*;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -268,6 +268,20 @@ impl ResampleMode {
         self.0 as i32
     }
 }
+
+#[derive(Clone, PartialEq, PartialOrd, Debug, Default)]
+pub struct SourceMidiEvent {
+    position_in_ppq: PositionInPPQ,
+    is_selected: bool,
+    is_muted: bool,
+    cc_shape: CcShape,
+    buf: Vec<u8>,
+}
+// impl Display for SourceMidiEvent{
+//     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+
+//     }
+// }
 
 /// A pitch shift mode, backed by a positive integer.
 ///

--- a/main/medium/src/misc_newtypes.rs
+++ b/main/medium/src/misc_newtypes.rs
@@ -1118,7 +1118,32 @@ impl TryFrom<f64> for PositionInQuarterNotes {
     }
 }
 
-/// This represents a position expressed as an amount of MIDI ticks (PPQ).
+impl std::ops::Add for PositionInQuarterNotes {
+    fn add(self, rhs: Self) -> Self {
+        PositionInQuarterNotes::new(self.get() + rhs.get())
+    }
+    type Output = Self;
+}
+impl std::ops::Sub for PositionInQuarterNotes {
+    fn sub(self, rhs: Self) -> Self {
+        PositionInQuarterNotes::new(self.get() - rhs.get())
+    }
+    type Output = Self;
+}
+impl std::ops::Div for PositionInQuarterNotes {
+    fn div(self, rhs: Self) -> Self {
+        PositionInQuarterNotes::new(self.get() / rhs.get())
+    }
+    type Output = Self;
+}
+impl std::ops::Mul for PositionInQuarterNotes {
+    fn mul(self, rhs: Self) -> Self {
+        PositionInQuarterNotes::new(self.get() * rhs.get())
+    }
+    type Output = Self;
+}
+
+/// This represents a position expressed as an amount of midi ticks (PPQ).
 ///
 /// Can be negative, see [`PositionInSeconds`](struct.PositionInSeconds.html).
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug, Default, Display)]

--- a/main/medium/src/misc_newtypes.rs
+++ b/main/medium/src/misc_newtypes.rs
@@ -1118,6 +1118,65 @@ impl TryFrom<f64> for PositionInQuarterNotes {
     }
 }
 
+/// This represents a position expressed as an amount of MIDI ticks (PPQ).
+///
+/// Can be negative, see [`PositionInSeconds`](struct.PositionInSeconds.html).
+#[derive(Copy, Clone, PartialEq, PartialOrd, Debug, Default, Display)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(try_from = "f64")
+)]
+pub struct PositionInPpq(pub(crate) f64);
+
+impl PositionInPpq {
+    /// Position at 0.0 quarter notes.
+    pub const ZERO: PositionInPpq = PositionInPpq(0.0);
+
+    fn is_valid(value: f64) -> bool {
+        !value.is_infinite() && !value.is_nan()
+    }
+
+    /// Creates a value.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if the given value is a special number.
+    pub fn new(value: f64) -> PositionInPpq {
+        assert!(
+            Self::is_valid(value),
+            "{} is not a valid PositionInQn value",
+            value
+        );
+        PositionInPpq(value)
+    }
+
+    /// Creates a PositionInQn value without bound checking.
+    ///
+    /// # Safety
+    ///
+    /// You must ensure that the given value is not a special number.
+    pub unsafe fn new_unchecked(value: f64) -> PositionInPpq {
+        PositionInPpq(value)
+    }
+
+    /// Returns the wrapped value.
+    pub const fn get(self) -> f64 {
+        self.0
+    }
+}
+
+impl TryFrom<f64> for PositionInPpq {
+    type Error = TryFromGreaterError<f64>;
+
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
+        if !Self::is_valid(value) {
+            return Err(TryFromGreaterError::new("value must be non-special", value));
+        }
+        Ok(PositionInPpq(value))
+    }
+}
+
 /// This represents a volume measured in decibel.
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug, Default, Display)]
 #[cfg_attr(

--- a/main/medium/src/misc_newtypes.rs
+++ b/main/medium/src/misc_newtypes.rs
@@ -1,5 +1,5 @@
 //! This module defines various newtypes in order to achieve more type safety.
-use crate::{CcShape, ReaperStr, ReaperStringArg, TryFromGreaterError};
+use crate::{ReaperStr, ReaperStringArg, TryFromGreaterError};
 use derive_more::*;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -269,14 +269,14 @@ impl ResampleMode {
     }
 }
 
-#[derive(Clone, PartialEq, PartialOrd, Debug, Default)]
-pub struct SourceMidiEvent {
-    position_in_ppq: PositionInPpq,
-    is_selected: bool,
-    is_muted: bool,
-    cc_shape: CcShape,
-    buf: Vec<u8>,
-}
+// #[derive(Clone, PartialEq, PartialOrd, Debug, Default)]
+// pub struct SourceMidiEvent {
+//     position_in_ppq: PositionInPpq,
+//     is_selected: bool,
+//     is_muted: bool,
+//     cc_shape: CcShapeKind,
+//     buf: Vec<u8>,
+// }
 // impl Display for SourceMidiEvent{
 //     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
 

--- a/main/medium/src/misc_newtypes.rs
+++ b/main/medium/src/misc_newtypes.rs
@@ -271,7 +271,7 @@ impl ResampleMode {
 
 #[derive(Clone, PartialEq, PartialOrd, Debug, Default)]
 pub struct SourceMidiEvent {
-    position_in_ppq: PositionInPPQ,
+    position_in_ppq: PositionInPpq,
     is_selected: bool,
     is_muted: bool,
     cc_shape: CcShape,

--- a/main/medium/src/reaper.rs
+++ b/main/medium/src/reaper.rs
@@ -5700,6 +5700,19 @@ impl<UsageScope> Reaper<UsageScope> {
         NonNull::new(ptr)
     }
 
+    /// # Safety
+    ///
+    /// REAPER can crash if passed item is invalid.
+    pub unsafe fn get_media_item_track(&self, item: MediaItem) -> ReaperFunctionResult<MediaTrack>
+    where
+        UsageScope: MainThreadOnly,
+    {
+        let ptr = self.low.GetMediaItemTrack(item.as_ptr());
+        MediaTrack::new(ptr).ok_or(ReaperFunctionError::new(
+            "Can not find item track. Probably, item is invalid.",
+        ))
+    }
+
     /// Returns the active take in this item.
     ///
     /// # Safety

--- a/main/medium/src/reaper.rs
+++ b/main/medium/src/reaper.rs
@@ -1548,6 +1548,54 @@ impl<UsageScope> Reaper<UsageScope> {
         PositionInSeconds::new(tpos)
     }
 
+    /// Converts the given quarter-note position to measure index
+    /// and returnes also measure bounds in quarter notes.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the given project is not valid anymore.
+    pub fn time_map_qn_to_measure(
+        &self,
+        project: ProjectContext,
+        qn: PositionInQuarterNotes,
+    ) -> TimeMapQNToMeasuresResult
+    where
+        UsageScope: AnyThread,
+    {
+        self.require_valid_project(project);
+        unsafe { self.time_map_qn_to_measure_unchecked(project, qn) }
+    }
+
+    /// Like [`time_map_qn_to_measure()`] but doesn't check if project is valid.
+    ///
+    /// # Safety
+    ///
+    /// REAPER can crash if you pass an invalid project.
+    ///
+    /// [`time_map_qn_to_measure()`]: #method.time_map_qn_to_measure
+    pub unsafe fn time_map_qn_to_measure_unchecked(
+        &self,
+        project: ProjectContext,
+        qn: PositionInQuarterNotes,
+    ) -> TimeMapQNToMeasuresResult
+    where
+        UsageScope: AnyThread,
+    {
+        let mut start_qn = MaybeUninit::zeroed();
+        let mut end_qn = MaybeUninit::zeroed();
+        let measure = self.low.TimeMap_QNToMeasures(
+            project.to_raw(),
+            qn.0,
+            start_qn.as_mut_ptr(),
+            end_qn.as_mut_ptr(),
+        );
+        TimeMapQNToMeasuresResult{
+            measure_index: measure,
+            start_qn: PositionInQuarterNotes::new(start_qn.assume_init()),
+            end_qn: PositionInQuarterNotes::new(end_qn.assume_init()),
+        }
+    }
+
     /// Converts the given quarter-note position to time.
     ///
     /// # Panics
@@ -7295,6 +7343,16 @@ pub struct TimeMapGetMeasureInfoResult {
     pub time_signature: TimeSignature,
     /// Tempo at that measure.
     pub tempo: Bpm,
+}
+
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub struct TimeMapQNToMeasuresResult {
+    /// Measue index in project.
+    pub measure_index: i32,
+    /// Start position of the measure in quarter notes.
+    pub start_qn: PositionInQuarterNotes,
+    /// End position of the measure in quarter notes.
+    pub end_qn: PositionInQuarterNotes,
 }
 
 /// Time signature.

--- a/main/medium/src/reaper.rs
+++ b/main/medium/src/reaper.rs
@@ -5975,6 +5975,25 @@ impl<UsageScope> Reaper<UsageScope> {
         )
     }
 
+    pub unsafe fn midi_get_all_events_raw(
+        &self,
+        take: MediaItemTake,
+        max_size: u32,
+    ) -> Option<Vec<u8>>
+    where
+        UsageScope: MainThreadOnly,
+    {
+        let (events, status) = with_buffer(max_size, |buffer, size| {
+            let mut size = MaybeUninit::new(size);
+            self.low
+                .MIDI_GetAllEvts(take.as_ptr(), buffer, size.as_mut_ptr())
+        });
+        match status {
+            true => Some(events),
+            false => None,
+        }
+    }
+
     /// Selects exactly one track and deselects all others.
     ///
     /// If `None` is passed, deselects all tracks.

--- a/main/medium/src/reaper.rs
+++ b/main/medium/src/reaper.rs
@@ -7,30 +7,29 @@ use reaper_low::{raw, register_plugin_destroy_hook};
 use crate::ProjectContext::CurrentProject;
 use crate::{
     require_non_null_panic, Accel, ActionValueChange, AddFxBehavior, AudioDeviceAttributeKey,
-    AutoSeekBehavior, AutomationMode, BookmarkId, BookmarkRef, Bpm, CcMessage, ChunkCacheHint,
-    CommandId, Db, DurationInSeconds, EditMode, EnvChunkName, FxAddByNameBehavior,
-    FxChainVisibility, FxPresetRef, FxShowInstruction, GangBehavior, GenericMessage,
-    GlobalAutomationModeOverride, HelpMode, Hidden, Hwnd, InitialAction, InputMonitoringMode,
-    InsertMediaFlag, InsertMediaMode, KbdSectionInfo, MasterTrackBehavior, MeasureMode, MediaItem,
-    MediaItemTake, MediaTrack, MessageBoxResult, MessageBoxType, MidiImportBehavior, MidiInput,
-    MidiInputDeviceId, MidiOutput, MidiOutputDeviceId, NativeColor, NormalizedPlayRate,
-    NotificationBehavior, OwnedPcmSource, OwnedReaperPitchShift, OwnedReaperResample, PanMode,
-    ParamId, PcmSource, PitchShiftMode, PitchShiftSubMode, PlaybackSpeedFactor, PluginContext,
-    PositionInBeats, PositionInPpq, PositionInQuarterNotes, PositionInSeconds, Progress,
-    ProjectContext, ProjectRef, PromptForActionResult, ReaProject, ReaperFunctionError,
-    ReaperFunctionResult, ReaperNormalizedFxParamValue, ReaperPanLikeValue, ReaperPanValue,
-    ReaperPointer, ReaperStr, ReaperString, ReaperStringArg, ReaperVersion, ReaperVolumeValue,
-    ReaperWidthValue, RecordArmMode, RecordingInput, RequiredViewMode, ResampleMode,
-    SectionContext, SectionId, SendTarget, SetTrackUiFlags, SoloMode, SourceMidiEvent,
-    StuffMidiMessageTarget, TakeAttributeKey, TimeModeOverride, TimeRangeType, TrackArea,
-    TrackAttributeKey, TrackDefaultsBehavior, TrackEnvelope, TrackFxChainType, TrackFxLocation,
-    TrackLocation, TrackMuteOperation, TrackPolarityOperation, TrackRecArmOperation,
-    TrackSendAttributeKey, TrackSendCategory, TrackSendDirection, TrackSendRef, TrackSoloOperation,
-    TransferBehavior, UiRefreshBehavior, UndoBehavior, UndoScope, ValueChange, VolumeSliderValue,
-    WindowContext,
+    AutoSeekBehavior, AutomationMode, BookmarkId, BookmarkRef, Bpm, ChunkCacheHint, CommandId, Db,
+    DurationInSeconds, EditMode, EnvChunkName, FxAddByNameBehavior, FxChainVisibility, FxPresetRef,
+    FxShowInstruction, GangBehavior, GlobalAutomationModeOverride, HelpMode, Hidden, Hwnd,
+    InitialAction, InputMonitoringMode, InsertMediaFlag, InsertMediaMode, KbdSectionInfo,
+    MasterTrackBehavior, MeasureMode, MediaItem, MediaItemTake, MediaTrack, MessageBoxResult,
+    MessageBoxType, MidiImportBehavior, MidiInput, MidiInputDeviceId, MidiOutput,
+    MidiOutputDeviceId, NativeColor, NormalizedPlayRate, NotificationBehavior, OwnedPcmSource,
+    OwnedReaperPitchShift, OwnedReaperResample, PanMode, ParamId, PcmSource, PitchShiftMode,
+    PitchShiftSubMode, PlaybackSpeedFactor, PluginContext, PositionInBeats, PositionInPpq,
+    PositionInQuarterNotes, PositionInSeconds, Progress, ProjectContext, ProjectRef,
+    PromptForActionResult, ReaProject, ReaperFunctionError, ReaperFunctionResult,
+    ReaperNormalizedFxParamValue, ReaperPanLikeValue, ReaperPanValue, ReaperPointer, ReaperStr,
+    ReaperString, ReaperStringArg, ReaperVersion, ReaperVolumeValue, ReaperWidthValue,
+    RecordArmMode, RecordingInput, RequiredViewMode, ResampleMode, SectionContext, SectionId,
+    SendTarget, SetTrackUiFlags, SoloMode, SourceMidiEventIterator, StuffMidiMessageTarget,
+    TakeAttributeKey, TimeModeOverride, TimeRangeType, TrackArea, TrackAttributeKey,
+    TrackDefaultsBehavior, TrackEnvelope, TrackFxChainType, TrackFxLocation, TrackLocation,
+    TrackMuteOperation, TrackPolarityOperation, TrackRecArmOperation, TrackSendAttributeKey,
+    TrackSendCategory, TrackSendDirection, TrackSendRef, TrackSoloOperation, TransferBehavior,
+    UiRefreshBehavior, UndoBehavior, UndoScope, ValueChange, VolumeSliderValue, WindowContext,
 };
 
-use helgoboss_midi::{ShortMessage, U4, U7};
+use helgoboss_midi::ShortMessage;
 use reaper_low::raw::GUID;
 
 use crate::util::{
@@ -42,8 +41,6 @@ use std::marker::PhantomData;
 use std::mem::MaybeUninit;
 use std::num::NonZeroU32;
 use std::path::{Path, PathBuf};
-
-const MAX_MIDI_MESSAGE_SIZE: usize = 2;
 
 /// Represents a privilege to execute functions which are safe to execute from any thread.
 pub trait AnyThread: private::Sealed {}
@@ -5978,7 +5975,21 @@ impl<UsageScope> Reaper<UsageScope> {
         )
     }
 
-    pub unsafe fn midi_get_all_events_raw(
+    pub unsafe fn midi_get_all_events_iter(
+        &self,
+        take: MediaItemTake,
+        max_size: u32,
+    ) -> Option<SourceMidiEventIterator>
+    where
+        UsageScope: MainThreadOnly,
+    {
+        match self.midi_get_all_events(take, max_size) {
+            None => None,
+            Some(buf) => Some(SourceMidiEventIterator::new(buf)),
+        }
+    }
+
+    pub unsafe fn midi_get_all_events(
         &self,
         take: MediaItemTake,
         max_size: u32,
@@ -5997,95 +6008,95 @@ impl<UsageScope> Reaper<UsageScope> {
         }
     }
 
-    pub unsafe fn midi_get_cc(
-        &self,
-        take: MediaItemTake,
-        cc_index: u32,
-    ) -> Option<SourceMidiEvent<CcMessage>> {
-        let (mut selected, mut muted) = (MaybeUninit::new(false), MaybeUninit::new(false));
-        let mut ppqpos = MaybeUninit::new(0.0);
-        let (mut chanmsg, mut chan, mut msg2, mut msg3) = (
-            MaybeUninit::new(0),
-            MaybeUninit::new(0),
-            MaybeUninit::new(0),
-            MaybeUninit::new(0),
-        );
+    // unsafe fn midi_get_cc(
+    //     &self,
+    //     take: MediaItemTake,
+    //     cc_index: u32,
+    // ) -> Option<SourceMidiEvent<CcMessage>> {
+    //     let (mut selected, mut muted) = (MaybeUninit::new(false), MaybeUninit::new(false));
+    //     let mut ppqpos = MaybeUninit::new(0.0);
+    //     let (mut chanmsg, mut chan, mut msg2, mut msg3) = (
+    //         MaybeUninit::new(0),
+    //         MaybeUninit::new(0),
+    //         MaybeUninit::new(0),
+    //         MaybeUninit::new(0),
+    //     );
 
-        let result = self.low.MIDI_GetCC(
-            take.as_ptr(),
-            cc_index as i32,
-            selected.as_mut_ptr(),
-            muted.as_mut_ptr(),
-            ppqpos.as_mut_ptr(),
-            chanmsg.as_mut_ptr(),
-            chan.as_mut_ptr(),
-            msg2.as_mut_ptr(),
-            msg3.as_mut_ptr(),
-        );
-        match result {
-            false => None,
-            true => Some(SourceMidiEvent::new(
-                PositionInPpq(ppqpos.assume_init()),
-                selected.assume_init(),
-                muted.assume_init(),
-                CcMessage {
-                    channel_message: U4::new(chanmsg.assume_init() as u8),
-                    channel: U4::new(chan.assume_init() as u8),
-                    cc_num: U7::new(msg2.assume_init() as u8),
-                    value: U7::new(msg3.assume_init() as u8),
-                },
-            )),
-        }
-    }
+    //     let result = self.low.MIDI_GetCC(
+    //         take.as_ptr(),
+    //         cc_index as i32,
+    //         selected.as_mut_ptr(),
+    //         muted.as_mut_ptr(),
+    //         ppqpos.as_mut_ptr(),
+    //         chanmsg.as_mut_ptr(),
+    //         chan.as_mut_ptr(),
+    //         msg2.as_mut_ptr(),
+    //         msg3.as_mut_ptr(),
+    //     );
+    //     match result {
+    //         false => None,
+    //         true => Some(SourceMidiEvent::new(
+    //             PositionInPpq(ppqpos.assume_init()),
+    //             selected.assume_init(),
+    //             muted.assume_init(),
+    //             CcMessage {
+    //                 channel_message: U4::new(chanmsg.assume_init() as u8),
+    //                 channel: U4::new(chan.assume_init() as u8),
+    //                 cc_num: U7::new(msg2.assume_init() as u8),
+    //                 value: U7::new(msg3.assume_init() as u8),
+    //             },
+    //         )),
+    //     }
+    // }
 
-    pub unsafe fn midi_get_evt(
-        &self,
-        take: MediaItemTake,
-        evt_index: u32,
-    ) -> Option<SourceMidiEvent<GenericMessage>> {
-        let (mut selected, mut muted) = (MaybeUninit::new(false), MaybeUninit::new(false));
-        let mut ppqpos = MaybeUninit::new(0.0);
-        let mut msg_size = MaybeUninit::new(5);
-        let (mut msg, result) = with_buffer(2, |msg, _| {
-            self.low.MIDI_GetEvt(
-                take.as_ptr(),
-                evt_index as i32,
-                selected.as_mut_ptr(),
-                muted.as_mut_ptr(),
-                ppqpos.as_mut_ptr(),
-                msg,
-                msg_size.as_mut_ptr(),
-            )
-        });
-        match result {
-            false => None,
-            true => {
-                let m_size = msg_size.assume_init() as u32;
-                if m_size > msg.len() as u32 {
-                    (msg, _) = with_buffer(m_size, |msg, _| {
-                        self.low.MIDI_GetEvt(
-                            take.as_ptr(),
-                            evt_index as i32,
-                            selected.as_mut_ptr(),
-                            muted.as_mut_ptr(),
-                            ppqpos.as_mut_ptr(),
-                            msg,
-                            msg_size.as_mut_ptr(),
-                        )
-                    });
-                }
-                Some(SourceMidiEvent::new(
-                    PositionInPpq(ppqpos.assume_init()),
-                    selected.assume_init(),
-                    muted.assume_init(),
-                    GenericMessage {
-                        size: m_size as u32,
-                        message: msg,
-                    },
-                ))
-            }
-        }
-    }
+    // unsafe fn midi_get_evt(
+    //     &self,
+    //     take: MediaItemTake,
+    //     evt_index: u32,
+    // ) -> Option<SourceMidiEvent<GenericMessage>> {
+    //     let (mut selected, mut muted) = (MaybeUninit::new(false), MaybeUninit::new(false));
+    //     let mut ppqpos = MaybeUninit::new(0.0);
+    //     let mut msg_size = MaybeUninit::new(4);
+    //     let (mut msg, result) = with_buffer(3, |msg, _| {
+    //         self.low.MIDI_GetEvt(
+    //             take.as_ptr(),
+    //             evt_index as i32,
+    //             selected.as_mut_ptr(),
+    //             muted.as_mut_ptr(),
+    //             ppqpos.as_mut_ptr(),
+    //             msg,
+    //             msg_size.as_mut_ptr(),
+    //         )
+    //     });
+    //     match result {
+    //         false => None,
+    //         true => {
+    //             let m_size = msg_size.assume_init() as u32;
+    //             if m_size > msg.len() as u32 {
+    //                 (msg, _) = with_buffer(m_size, |msg, _| {
+    //                     self.low.MIDI_GetEvt(
+    //                         take.as_ptr(),
+    //                         evt_index as i32,
+    //                         selected.as_mut_ptr(),
+    //                         muted.as_mut_ptr(),
+    //                         ppqpos.as_mut_ptr(),
+    //                         msg,
+    //                         msg_size.as_mut_ptr(),
+    //                     )
+    //                 });
+    //             }
+    //             Some(SourceMidiEvent::new(
+    //                 PositionInPpq(ppqpos.assume_init()),
+    //                 selected.assume_init(),
+    //                 muted.assume_init(),
+    //                 GenericMessage {
+    //                     size: m_size as u32,
+    //                     message: msg,
+    //                 },
+    //             ))
+    //         }
+    //     }
+    // }
 
     /// Selects exactly one track and deselects all others.
     ///

--- a/main/medium/src/source_midi.rs
+++ b/main/medium/src/source_midi.rs
@@ -1,0 +1,122 @@
+// use crate::{CcShapeKind, MidiFrameOffset, PositionInPpq};
+
+// #[derive(Debug, Clone)]
+// pub struct MidiMessage {
+//     size: u32,
+//     bytes: Box<[u8]>,
+// }
+// impl MidiMessage {
+//     pub fn size(&self) -> u32 {
+//         self.size
+//     }
+//     pub fn get(self) -> Box<[u8]> {
+//         self.bytes
+//     }
+//     pub fn set(&mut self, bytes: Box<[u8]>) {
+//         self.bytes = bytes;
+//     }
+// }
+
+// pub struct EnumSourceMidiEvent {
+//     pub message: MidiMessage,
+//     pub offset: MidiFrameOffset
+// }
+// impl EnumSourceMidiEvent{
+//     pub fn new(message:MidiMessage, offset:MidiFrameOffset)->Self{
+//         Self { message, offset }
+//     }
+// }
+
+// pub enum SourceMidiEvent{
+//     Cc(SourceCcEvent),
+//     NoteOn(SourceNoteOnEvent),
+
+// }
+
+use helgoboss_midi::{U4, U7};
+
+use crate::PositionInPpq;
+
+#[derive(Debug)]
+pub struct SourceMidiEvent<T> {
+    position_in_ppq: PositionInPpq,
+    is_selected: bool,
+    is_muted: bool,
+    event: T,
+}
+impl<T> SourceMidiEvent<T> {
+    pub fn new(position_in_ppq: PositionInPpq, selected: bool, muted: bool, event: T) -> Self {
+        Self {
+            position_in_ppq,
+            is_selected: selected,
+            is_muted: muted,
+            event,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct GenericMessage{
+    pub size:u32,
+    pub message: Vec<u8>
+}
+
+#[derive(Debug)]
+pub struct CcMessage {
+    pub channel_message: U4,
+    pub channel: U4,
+    pub cc_num: U7,
+    pub value: U7,
+}
+// impl SourceMidiEvent_bck {
+//     pub fn get_pos_in_ppq(&self) -> PositionInPpq {
+//         self.position_in_ppq
+//     }
+//     pub fn set_pos_in_ppq(&mut self, position: PositionInPpq) {
+//         self.position_in_ppq = position;
+//     }
+//     pub fn is_selected(&self) -> bool {
+//         self.is_selected
+//     }
+//     pub fn set_selected(&mut self, selected: bool) {
+//         self.is_selected = selected;
+//     }
+//     pub fn is_muted(&self) -> bool {
+//         self.is_muted
+//     }
+//     pub fn set_muted(&mut self, muted: bool) {
+//         self.is_muted = muted;
+//     }
+//     pub fn get_message(self) -> MidiMessage {
+//         self.message
+//     }
+//     pub fn set_message(&mut self, message: MidiMessage) {
+//         self.message = message
+//     }
+//     pub fn get_cc_shape(self) -> CcShape {
+//         self.cc_shape
+//     }
+//     pub fn set_cc_shape(&mut self, cc_shape: CcShape) {
+//         self.cc_shape = cc_shape;
+//     }
+// }
+
+// pub struct CcShape {
+//     kind: CcShapeKind,
+//     tension: Option<f32>,
+// }
+// impl CcShape {
+//     pub fn get_kind(&self) -> CcShapeKind {
+//         self.kind
+//     }
+//     pub fn set_kind(&mut self, kind: CcShapeKind) {
+//         self.kind = kind;
+//     }
+//     pub fn get_tension(&self) -> Option<f32> {
+//         self.tension
+//     }
+//     pub fn set_tension(&mut self, tension: Option<f32>) {
+//         self.tension = tension;
+//     }
+//     // pub fn from_events(events:)
+// }

--- a/test/test/src/tests.rs
+++ b/test/test/src/tests.rs
@@ -120,6 +120,7 @@ pub fn create_test_steps() -> impl Iterator<Item = TestStep> {
         unsolo_track(),
         generate_guid(),
         main_section_functions(),
+        midi_functions(),
         register_and_unregister_action(),
         register_and_unregister_toggle_action(),
     ]
@@ -139,7 +140,6 @@ pub fn create_test_steps() -> impl Iterator<Item = TestStep> {
         set_project_play_rate(),
         get_project_tempo(),
         set_project_tempo(),
-        track_midi_functions(),
         swell(),
     ]
     .into_iter();
@@ -3578,7 +3578,7 @@ fn add_track_fx_by_original_name(get_fx_chain: GetFxChain) -> TestStep {
     )
 }
 
-fn track_midi_functions() -> TestStep {
+fn midi_functions() -> TestStep {
     step(AllVersions, "Test MIDI functions on track.", |_, _| {
         let reaper = Reaper::get();
         let project = reaper.current_project();
@@ -3621,16 +3621,16 @@ fn track_midi_functions() -> TestStep {
                     .get_track_midi_note_name_ex(project.context(), track.raw(), 60, 0)
                     .ok_or("should be set")?
                     .to_str(),
-                "test name ahh"
+                "test name"
             );
         }
-        assert_eq!("ahhh!", "Not!");
 
         project.remove_track(&track);
 
         Ok(())
     })
 }
+
 
 fn get_track(index: u32) -> Result<Track, &'static str> {
     Reaper::get()

--- a/test/test/src/tests.rs
+++ b/test/test/src/tests.rs
@@ -139,6 +139,7 @@ pub fn create_test_steps() -> impl Iterator<Item = TestStep> {
         set_project_play_rate(),
         get_project_tempo(),
         set_project_tempo(),
+        track_midi_functions(),
         swell(),
     ]
     .into_iter();
@@ -3575,6 +3576,60 @@ fn add_track_fx_by_original_name(get_fx_chain: GetFxChain) -> TestStep {
             Ok(())
         },
     )
+}
+
+fn track_midi_functions() -> TestStep {
+    step(AllVersions, "Test MIDI functions on track.", |_, _| {
+        let reaper = Reaper::get();
+        let project = reaper.current_project();
+
+        let track = project.add_track()?;
+
+        let medium = reaper.medium_reaper();
+
+        unsafe {
+            let item = medium.create_midi_item_in_proj(track.raw(), 1.0, 2.0, true)?;
+            let take = medium
+                .get_active_take(item)
+                .ok_or("No tke in created item!")?;
+
+            assert!(medium.take_is_midi(&take));
+            let track_index = track.index().ok_or("Can not take Track index.")?;
+            match medium.set_track_midi_note_name(track_index, 60, 0, "test name") {
+                true => Ok(true),
+                false => Err("returned false"),
+            }?;
+            match medium.set_track_midi_note_name_ex(
+                project.context(),
+                track.raw(),
+                61,
+                -1,
+                "test name_ex",
+            ) {
+                true => Ok(true),
+                false => Err("returned false"),
+            }?;
+            assert_eq!(
+                medium
+                    .get_track_midi_note_name(track_index, 61, 3)
+                    .ok_or("should be set")?
+                    .to_str(),
+                "test name_ex"
+            );
+            assert_eq!(
+                medium
+                    .get_track_midi_note_name_ex(project.context(), track.raw(), 60, 0)
+                    .ok_or("should be set")?
+                    .to_str(),
+                "test name ahh"
+            );
+        }
+        assert_eq!("ahhh!", "Not!");
+
+        project.remove_track(&track);
+
+        Ok(())
+    })
 }
 
 fn get_track(index: u32) -> Result<Track, &'static str> {


### PR DESCRIPTION
I've just built an iterator, that returns arbitrary "generic" midi events with PPQ position and all flags unpacked.

Then the decision is needed what to do:
- stop on this point and just implement `midi_set_all_evts` and make everything clean
- implement the rest of the midi_* functions as pure wrap on top of low-level
- implement iterators over various type of midi-events. This breaks a bit medium-level API philosophy, but it should be more safe, than leave not very optimized raw functions instead.