### PR TITLE
Medium-level API: Add various `ext_state` and corresponding changes.

### DIFF
--- a/main/medium/src/util.rs
+++ b/main/medium/src/util.rs
@@ -47,14 +47,26 @@ pub fn with_string_buffer_internal<T>(
     (string, result)
 }
 
+pub fn create_string_buffer(max_size: u32) -> *mut i8 {
+    let vec: Vec<u8> = vec![0; max_size as usize];
+    let c_string = unsafe { CString::from_vec_unchecked(vec) };
+    let raw = c_string.into_raw();
+    raw
+}
+
 pub fn with_buffer<T>(
     max_size: u32,
     fill_buffer: impl FnOnce(*mut c_char, i32) -> T,
 ) -> (Vec<u8>, T) {
-    let mut vec: Vec<u8> = vec![0; max_size as usize];
-    let raw = vec.as_mut_ptr() as *mut c_char;
+    let (vec, raw) = create_buffer(max_size);
     let result = fill_buffer(raw, max_size as i32);
     (vec, result)
+}
+
+pub fn create_buffer(max_size: u32) -> (Vec<u8>, *mut i8) {
+    let mut vec: Vec<u8> = vec![0; max_size as usize];
+    let raw = vec.as_mut_ptr() as *mut c_char;
+    (vec, raw)
 }
 
 /// We really need a box here in order to obtain a thin pointer. We must not consume it, that's why


### PR DESCRIPTION
`set_ext_state`
`get_ext_state`
`has_ext_state`
`delete_ext_state`
`set_project_ext_state`
`set_project_ext_state_unchecked`
`get_project_ext_state`
`get_project_ext_state_unchecked`
`delete_project_ext_state` — verbose function to pass empty string. `delete_project_ext_state_unchecked`
`enum_project_ext_state` with `EnumProjectExtStateResult` `enum_project_ext_state_unchecked`

As `enum_project_ext_state` expects two string buffers, also introduced: `create_string_buffer`
`create_buffer`

Covered with tests.