### PR TITLE
Feat: add support for registering functions in custom sections

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM rust:1.69.0
+FROM rustlang/rust:nightly
 RUN apt update && apt install -y llvm-dev libclang-dev clang

--- a/main/low/build.rs
+++ b/main/low/build.rs
@@ -180,6 +180,7 @@ mod codegen {
                 .whitelist_type("HINSTANCE")
                 .whitelist_type("reaper_plugin_info_t")
                 .whitelist_type("gaccel_register_t")
+                .whitelist_type("custom_action_register_t")
                 .whitelist_type("accelerator_register_t")
                 .whitelist_type("audio_hook_register_t")
                 .whitelist_type("midi_realtime_write_struct_t")

--- a/main/low/src/bindings.rs
+++ b/main/low/src/bindings.rs
@@ -1265,6 +1265,20 @@ pub mod root {
     }
     #[repr(C)]
     #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+    pub struct _REAPER_custom_action_register_t {
+        pub uniqueSectionId: ::std::os::raw::c_int,
+        pub idStr: *const ::std::os::raw::c_char,
+        pub name: *const ::std::os::raw::c_char,
+        pub extra: *mut ::std::os::raw::c_void,
+    }
+    impl Default for _REAPER_custom_action_register_t {
+        fn default() -> Self {
+            unsafe { ::std::mem::zeroed() }
+        }
+    }
+    pub type custom_action_register_t = root::_REAPER_custom_action_register_t;
+    #[repr(C)]
+    #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
     pub struct _REAPER_gaccel_register_t {
         pub accel: root::ACCEL,
         pub desc: *const ::std::os::raw::c_char,

--- a/main/low/src/raw.rs
+++ b/main/low/src/raw.rs
@@ -6,7 +6,7 @@ use std::os::raw::{c_int, c_void};
 
 /// Structs, types and constants defined by REAPER.
 pub use super::bindings::root::{
-    accelerator_register_t, audio_hook_register_t, gaccel_register_t, midi_Input, midi_Output,
+    accelerator_register_t, audio_hook_register_t, gaccel_register_t, custom_action_register_t, midi_Input, midi_Output,
     midi_realtime_write_struct_t, preview_register_t, reaper_plugin_info_t, IReaperControlSurface,
     IReaperPitchShift, KbdCmd, KbdSectionInfo, MIDI_event_t, MIDI_eventlist, MediaItem,
     MediaItem_Take, MediaTrack, PCM_sink, PCM_source, PCM_source_peaktransfer_t,

--- a/main/medium/src/custom_action_register.rs
+++ b/main/medium/src/custom_action_register.rs
@@ -1,0 +1,63 @@
+use crate::{AcceleratorBehavior, AcceleratorKeyCode, CommandId, ReaperStr, ReaperStringArg};
+use enumflags2::BitFlags;
+use reaper_low::raw;
+use reaper_low::raw::custom_action_register_t;
+use std::borrow::Cow;
+use std::os::raw::c_ushort;
+
+/// A kind of action descriptor.
+///
+/// Contains action description, command ID and default key binding.
+//
+// Case 2: Internals exposed: yes | vtable: no
+// ===========================================
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+pub struct OwnedCustomActionRegister {
+    owned_desc: Cow<'static, ReaperStr>,
+    inner: custom_action_register_t,
+}
+
+impl OwnedCustomActionRegister {
+    /// Creates an action descriptor without key binding.
+    pub fn without_key_binding(
+        desc: impl Into<ReaperStringArg<'static>>,
+        section_id: i32,
+    ) -> OwnedCustomActionRegister {
+        let desc = desc.into().into_inner();
+        let desc_ptr = desc.as_ptr();
+        OwnedCustomActionRegister {
+            owned_desc: desc,
+            inner: raw::custom_action_register_t {
+                uniqueSectionId: section_id,
+                idStr: std::ptr::null(),
+                name: desc_ptr,
+                extra: std::ptr::null_mut(),
+            },
+        }
+    }
+
+    /// Creates an action descriptor with key binding.
+    pub fn with_key_binding(
+        desc: impl Into<ReaperStringArg<'static>>,
+        section_id: i32,
+    ) -> OwnedCustomActionRegister {
+        let desc = desc.into().into_inner();
+        let desc_ptr = desc.as_ptr();
+        OwnedCustomActionRegister {
+            owned_desc: desc,
+            inner: raw::custom_action_register_t {
+                uniqueSectionId: section_id,
+                idStr: std::ptr::null(),
+                name: desc_ptr,
+                extra: std::ptr::null_mut(),
+            },
+        }
+    }
+}
+
+impl AsRef<raw::custom_action_register_t> for OwnedCustomActionRegister {
+    fn as_ref(&self) -> &custom_action_register_t {
+        &self.inner
+    }
+}
+

--- a/main/medium/src/custom_action_register.rs
+++ b/main/medium/src/custom_action_register.rs
@@ -53,6 +53,25 @@ impl OwnedCustomActionRegister {
             },
         }
     }
+
+    /// Creates an action descriptor with a custom idStr (command name).
+    pub fn with_id_str(
+        desc: impl Into<ReaperStringArg<'static>>,
+        section_id: i32,
+        id_str: &std::ffi::CStr,
+    ) -> OwnedCustomActionRegister {
+        let desc = desc.into().into_inner();
+        let desc_ptr = desc.as_ptr();
+        OwnedCustomActionRegister {
+            owned_desc: desc,
+            inner: raw::custom_action_register_t {
+                uniqueSectionId: section_id,
+                idStr: id_str.as_ptr(),
+                name: desc_ptr,
+                extra: std::ptr::null_mut(),
+            },
+        }
+    }
 }
 
 impl AsRef<raw::custom_action_register_t> for OwnedCustomActionRegister {

--- a/main/medium/src/lib.rs
+++ b/main/medium/src/lib.rs
@@ -350,6 +350,9 @@ pub use reaper_pointer::*;
 mod gaccel_register;
 pub use gaccel_register::*;
 
+mod custom_action_register;
+pub use custom_action_register::*;
+
 mod accelerator_register;
 pub use accelerator_register::*;
 

--- a/main/medium/src/misc_enums.rs
+++ b/main/medium/src/misc_enums.rs
@@ -839,6 +839,13 @@ pub enum RegistrationObject<'a> {
     /// (IReaperControlSurface*)instance
     /// ```
     CsurfInst(Handle<raw::IReaperControlSurface>),
+    /// A custom action registration.
+    ///
+    /// Extract from `reaper_plugin.h`:
+    /// ```text
+    /// register("custom_action", custom_action_register_t*) registers a custom action in a specific section.
+    /// ```
+    CustomAction(Handle<raw::custom_action_register_t>),
     /// If a variant is missing in this enum, you can use this custom one as a resort.
     ///
     /// Use [`custom()`] to create this variant.
@@ -975,6 +982,10 @@ impl<'a> RegistrationObject<'a> {
             CsurfInst(inst) => PluginRegistration {
                 key: reaper_str!("csurf_inst").into(),
                 value: inst.as_ptr() as _,
+            },
+            CustomAction(reg) => PluginRegistration {
+                key: reaper_str!("custom_action").into(),
+                value: reg.as_ptr() as _,
             },
             Custom(key, value) => PluginRegistration {
                 key: key.into_owned().into(),


### PR DESCRIPTION
This needs to be tested a bit more, and needs to be refactored to be more in line with the scope of medium api vs high api (ill update request when I get to it), but this enabled registering an action in the same way as the normal register_action function, but under a different name to avoid compatibility issues.

If rx functions, everything else worked related to gaccel and custom functions, I would propose we merge this with the normal register_action function with an optional section parameter that uses custom_acton_register_t under the hood instead if we can get everything else working. But for now, keeping them separate it probably a good idea